### PR TITLE
Add match and ignore options for URL patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Options:
                                         # Default: Mozilla/5.0 (compatible; DeadFinder/1.6.1;)
   p, [--proxy=PROXY]                    # Proxy server to use for requests
      [--proxy-auth=PROXY_AUTH]          # Proxy server authentication credentials
+  m, [--match=MATCH]                    # Match the URL with the given pattern
+  i, [--ignore=IGNORE]                  # Ignore the URL with the given pattern
   s, [--silent], [--no-silent]          # Silent mode
   v, [--verbose], [--no-verbose]        # Verbose mode
 ```

--- a/deadfinder.gemspec
+++ b/deadfinder.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://www.hahwul.com/projects/deadfinder/'
   s.license = 'MIT'
   s.executables << 'deadfinder'
-  s.files = ['lib/deadfinder.rb', 'lib/deadfinder/logger.rb', 'lib/deadfinder/runner.rb', 'lib/deadfinder/cli.rb', 'lib/deadfinder/utils.rb', 'lib/deadfinder/version.rb', 'lib/deadfinder/http_client.rb']
+  s.files = ['lib/deadfinder.rb', 'lib/deadfinder/logger.rb', 'lib/deadfinder/runner.rb', 'lib/deadfinder/cli.rb', 'lib/deadfinder/utils.rb', 'lib/deadfinder/version.rb', 'lib/deadfinder/http_client.rb', 'lib/deadfinder/url_pattern_matcher.rb']
   s.metadata['rubygems_mfa_required'] = 'true'
   s.metadata['source_code_uri'] = 'https://github.com/hahwul/deadfinder'
   s.required_ruby_version = '>= 3.3.0'

--- a/lib/deadfinder/cli.rb
+++ b/lib/deadfinder/cli.rb
@@ -18,6 +18,8 @@ module DeadFinder
                               desc: 'User-Agent string to use for requests'
     class_option :proxy, aliases: :p, default: '', type: :string, desc: 'Proxy server to use for requests'
     class_option :proxy_auth, default: '', type: :string, desc: 'Proxy server authentication credentials'
+    class_option :match, aliases: :m, default: '', type: :string, desc: 'Match the URL with the given pattern'
+    class_option :ignore, aliases: :i, default: '', type: :string, desc: 'Ignore the URL with the given pattern'
     class_option :silent, aliases: :s, default: false, type: :boolean, desc: 'Silent mode'
     class_option :verbose, aliases: :v, default: false, type: :boolean, desc: 'Verbose mode'
 

--- a/lib/deadfinder/runner.rb
+++ b/lib/deadfinder/runner.rb
@@ -41,14 +41,22 @@ module DeadFinder
       links = extract_links(page)
 
       if options['match'] != ''
-        links.each do |type, urls|
-          links[type] = urls.select { |url| DeadFinder::UrlPatternMatcher.match?(url, options['match']) }
+        begin
+          links.each do |type, urls|
+        links[type] = urls.select { |url| DeadFinder::UrlPatternMatcher.match?(url, options['match']) }
+          end
+        rescue RegexpError => e
+          Logger.error "Invalid match pattern: #{e.message}"
         end
       end
 
       if options['ignore'] != ''
-        links.each do |type, urls|
-          links[type] = urls.reject { |url| DeadFinder::UrlPatternMatcher.ignore?(url, options['ignore']) }
+        begin
+          links.each do |type, urls|
+            links[type] = urls.reject { |url| DeadFinder::UrlPatternMatcher.ignore?(url, options['ignore']) }
+          end
+        rescue RegexpError => e
+          Logger.error "Invalid match pattern: #{e.message}"
         end
       end
 

--- a/lib/deadfinder/runner.rb
+++ b/lib/deadfinder/runner.rb
@@ -7,6 +7,7 @@ require 'net/http'
 require 'openssl'
 require 'deadfinder/logger'
 require 'deadfinder/http_client'
+require 'deadfinder/url_pattern_matcher'
 
 module DeadFinder
   # Runner class for executing the main logic
@@ -21,7 +22,11 @@ module DeadFinder
         'worker_headers' => [],
         'silent' => true,
         'verbose' => false,
-        'include30x' => false
+        'include30x' => false,
+        'proxy' => '',
+        'proxy_auth' => '',
+        'match' => '',
+        'ignore' => '',
       }
     end
 
@@ -34,6 +39,18 @@ module DeadFinder
       end
       page = Nokogiri::HTML(URI.open(target, headers))
       links = extract_links(page)
+
+      if options['match'] != ''
+        links.each do |type, urls|
+          links[type] = urls.select { |url| DeadFinder::UrlPatternMatcher.match?(url, options['match']) }
+        end
+      end
+
+      if options['ignore'] != ''
+        links.each do |type, urls|
+          links[type] = urls.reject { |url| DeadFinder::UrlPatternMatcher.ignore?(url, options['ignore']) }
+        end
+      end
 
       total_links_count = links.values.flatten.length
       link_info = links.map { |type, urls| "#{type}:#{urls.length}" if urls.length.positive? }

--- a/lib/deadfinder/url_pattern_matcher.rb
+++ b/lib/deadfinder/url_pattern_matcher.rb
@@ -1,14 +1,20 @@
 # frozen_string_literal: true
 
+require 'timeout'
+
 module DeadFinder
   # URL pattern matcher module
   module UrlPatternMatcher
     def self.match?(url, pattern)
-      Regexp.new(pattern).match?(url)
+      Timeout.timeout(1) { Regexp.new(pattern).match?(url) }
+    rescue Timeout::Error
+      false
     end
 
     def self.ignore?(url, pattern)
-      Regexp.new(pattern).match?(url)
+      Timeout.timeout(1) { Regexp.new(pattern).match?(url) }
+    rescue Timeout::Error
+      false
     end
   end
 end

--- a/lib/deadfinder/url_pattern_matcher.rb
+++ b/lib/deadfinder/url_pattern_matcher.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module DeadFinder
+  # URL pattern matcher module
+  module UrlPatternMatcher
+    def self.match?(url, pattern)
+      Regexp.new(pattern).match?(url)
+    end
+
+    def self.ignore?(url, pattern)
+      Regexp.new(pattern).match?(url)
+    end
+  end
+end

--- a/spec/dead_finder/runner_spec.rb
+++ b/spec/dead_finder/runner_spec.rb
@@ -50,6 +50,30 @@ RSpec.describe DeadFinder::Runner do
         expect(DeadFinder.output[target]).not_to include('http://example.com/valid')
       end
     end
+
+    context 'with invalid match option' do
+      before do
+        options['match'] = '[' # Invalid regex pattern
+        allow(Logger).to receive(:error)
+      end
+
+      it 'logs an error for invalid match pattern' do
+        runner.run(target, options)
+        expect(Logger).to have_received(:error).with(/Invalid match pattern/)
+      end
+    end
+
+    context 'with invalid ignore option' do
+      before do
+        options['ignore'] = '[' # Invalid regex pattern
+        allow(Logger).to receive(:error)
+      end
+
+      it 'logs an error for invalid ignore pattern' do
+        runner.run(target, options)
+        expect(Logger).to have_received(:error).with(/Invalid match pattern/)
+      end
+    end
   end
 
   describe '#worker' do

--- a/spec/dead_finder/url_pattern_matcher_spec.rb
+++ b/spec/dead_finder/url_pattern_matcher_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe DeadFinder::UrlPatternMatcher do
     it 'returns false when the URL does not match the pattern' do
       expect(described_class.match?('http://example.com', 'nonexistent')).to be false
     end
+
+    it 'raises an error when the pattern is an invalid regex' do
+      expect { described_class.match?('http://example.com', '[') }.to raise_error(RegexpError)
+    end
   end
 
   describe '.ignore?' do
@@ -20,6 +24,10 @@ RSpec.describe DeadFinder::UrlPatternMatcher do
 
     it 'returns false when the URL does not match the pattern' do
       expect(described_class.ignore?('http://example.com', 'nonexistent')).to be false
+    end
+
+    it 'raises an error when the pattern is an invalid regex' do
+      expect { described_class.ignore?('http://example.com', '[') }.to raise_error(RegexpError)
     end
   end
 end

--- a/spec/dead_finder/url_pattern_matcher_spec.rb
+++ b/spec/dead_finder/url_pattern_matcher_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'deadfinder/url_pattern_matcher'
+
+RSpec.describe DeadFinder::UrlPatternMatcher do
+  describe '.match?' do
+    it 'returns true when the URL matches the pattern' do
+      expect(described_class.match?('http://example.com', 'example')).to be true
+    end
+
+    it 'returns false when the URL does not match the pattern' do
+      expect(described_class.match?('http://example.com', 'nonexistent')).to be false
+    end
+  end
+
+  describe '.ignore?' do
+    it 'returns true when the URL matches the pattern' do
+      expect(described_class.ignore?('http://example.com', 'example')).to be true
+    end
+
+    it 'returns false when the URL does not match the pattern' do
+      expect(described_class.ignore?('http://example.com', 'nonexistent')).to be false
+    end
+  end
+end


### PR DESCRIPTION
Introduce functionality to match and ignore URLs based on specified patterns, enhancing the filtering capabilities of the tool. Include corresponding tests for the new matcher module.