### PR TITLE
Add --debug flag and refactor Logger

### DIFF
--- a/lib/deadfinder.rb
+++ b/lib/deadfinder.rb
@@ -38,15 +38,16 @@ module DeadFinder
   end
 
   def self.run_url(url, options)
+    DeadFinder::Logger.apply_options(options)
     run_with_target(url, options)
   end
 
   def self.run_sitemap(sitemap_url, options)
-    Logger.set_silent if options['silent']
+    DeadFinder::Logger.apply_options(options)
     app = Runner.new
     base_uri = URI(sitemap_url)
     sitemap = SitemapParser.new(sitemap_url, recurse: true)
-    Logger.info "Found #{sitemap.to_a.size} URLs from #{sitemap_url}"
+    DeadFinder::Logger.info "Found #{sitemap.to_a.size} URLs from #{sitemap_url}"
     sitemap.to_a.each do |url|
       turl = generate_url(url, base_uri)
       run_with_target(turl, options, app)
@@ -55,8 +56,8 @@ module DeadFinder
   end
 
   def self.run_with_input(options)
-    Logger.set_silent if options['silent']
-    Logger.info 'Reading input'
+    DeadFinder::Logger.apply_options(options)
+    DeadFinder::Logger.info 'Reading input'
     app = Runner.new
     Array(yield).each do |target|
       run_with_target(target, options, app)
@@ -65,7 +66,7 @@ module DeadFinder
   end
 
   def self.run_with_target(target, options, app = Runner.new)
-    Logger.target "Fetching #{target}"
+    DeadFinder::Logger.target "Fetching #{target}"
     app.run(target, options)
   end
 

--- a/lib/deadfinder/cli.rb
+++ b/lib/deadfinder/cli.rb
@@ -22,6 +22,7 @@ module DeadFinder
     class_option :ignore, aliases: :i, default: '', type: :string, desc: 'Ignore the URL with the given pattern'
     class_option :silent, aliases: :s, default: false, type: :boolean, desc: 'Silent mode'
     class_option :verbose, aliases: :v, default: false, type: :boolean, desc: 'Verbose mode'
+    class_option :debug, default: false, type: :boolean, desc: 'Debug mode'
 
     desc 'pipe', 'Scan the URLs from STDIN. (e.g., cat urls.txt | deadfinder pipe)'
     def pipe
@@ -45,7 +46,7 @@ module DeadFinder
 
     desc 'version', 'Show version.'
     def version
-      Logger.info "deadfinder #{DeadFinder::VERSION}"
+      DeadFinder::Logger.info "deadfinder #{DeadFinder::VERSION}"
     end
   end
 end

--- a/lib/deadfinder/logger.rb
+++ b/lib/deadfinder/logger.rb
@@ -2,68 +2,102 @@
 
 require 'colorize'
 
-class Logger
-  @silent = false
-  @mutex = Mutex.new
+module DeadFinder
+  class Logger
+    @silent = false
+    @verbose = false
+    @debug = false
+    @mutex = Mutex.new
 
-  def self.set_silent
-    @mutex.synchronize { @silent = true }
-  end
+    def self.apply_options(options)
+      set_silent if options['silent']
+      set_verbose if options['verbose']
+      set_debug if options['debug']
+    end
 
-  def self.unset_silent
-    @mutex.synchronize { @silent = false }
-  end
+    def self.set_silent
+      @mutex.synchronize { @silent = true }
+    end
 
-  def self.silent?
-    @mutex.synchronize { @silent }
-  end
+    def self.set_verbose
+      @mutex.synchronize { @verbose = true }
+    end
 
-  def self.log(prefix, text, color)
-    return if silent?
+    def self.set_debug
+      @mutex.synchronize { @debug = true }
+    end
 
-    puts prefix.colorize(color) + text.to_s
-  end
+    def self.unset_debug
+      @mutex.synchronize { @debug = false }
+    end
 
-  def self.sub_log(prefix, is_end, text, color)
-    return if silent?
+    def self.unset_verbose
+      @mutex.synchronize { @verbose = false }
+    end
 
-    indent = is_end ? '  └── ' : '  ├── '
-    puts indent.colorize(color) + prefix.colorize(color) + text.to_s
-  end
+    def self.debug?
+      @mutex.synchronize { @debug }
+    end
 
-  def self.debug(text)
-    log('✓ ', text, :green)
-  end
+    def self.verbose?
+      @mutex.synchronize { @verbose }
+    end
 
-  def self.info(text)
-    log('ℹ ', text, :blue)
-  end
+    def self.unset_silent
+      @mutex.synchronize { @silent = false }
+    end
 
-  def self.error(text)
-    log('⚠︎ ', text, :red)
-  end
+    def self.silent?
+      @mutex.synchronize { @silent }
+    end
 
-  def self.target(text)
-    log('► ', text, :green)
-  end
+    def self.log(prefix, text, color)
+      return if silent?
 
-  def self.sub_info(text)
-    log('  ● ', text, :blue)
-  end
+      puts prefix.colorize(color) + text.to_s
+    end
 
-  def self.sub_complete(text)
-    sub_log('● ', true, text, :blue)
-  end
+    def self.sub_log(prefix, is_end, text, color)
+      return if silent?
 
-  def self.found(text)
-    sub_log('✘ ', false, text, :red)
-  end
+      indent = is_end ? '  └── ' : '  ├── '
+      puts indent.colorize(color) + prefix.colorize(color) + text.to_s
+    end
 
-  def self.verbose(text)
-    sub_log('➜ ', false, text, :yellow)
-  end
+    def self.debug(text)
+      log('❀ ', text, :yellow) if debug?
+    end
 
-  def self.verbose_ok(text)
-    sub_log('✓ ', false, text, :green)
+    def self.info(text)
+      log('ℹ ', text, :blue)
+    end
+
+    def self.error(text)
+      log('⚠︎ ', text, :red)
+    end
+
+    def self.target(text)
+      log('► ', text, :green)
+    end
+
+    def self.sub_info(text)
+      log('  ● ', text, :blue)
+    end
+
+    def self.sub_complete(text)
+      sub_log('● ', true, text, :blue)
+    end
+
+    def self.found(text)
+      sub_log('✘ ', false, text, :red)
+    end
+
+    def self.verbose(text)
+      sub_log('➜ ', false, text, :yellow) if verbose?
+    end
+
+    def self.verbose_ok(text)
+      sub_log('✓ ', false, text, :green) if verbose?
+    end
   end
 end

--- a/lib/deadfinder/runner.rb
+++ b/lib/deadfinder/runner.rb
@@ -31,7 +31,7 @@ module DeadFinder
     end
 
     def run(target, options)
-      Logger.set_silent if options['silent']
+      DeadFinder::Logger.apply_options(options)
       headers = options['headers'].each_with_object({}) do |header, hash|
         kv = header.split(': ')
         hash[kv[0]] = kv[1]
@@ -40,13 +40,15 @@ module DeadFinder
       page = Nokogiri::HTML(URI.open(target, headers))
       links = extract_links(page)
 
+      DeadFinder::Logger.debug "#{CACHE_QUE.size} URLs in queue, #{CACHE_SET.size} URLs in cache"
+
       if options['match'] != ''
         begin
           links.each do |type, urls|
         links[type] = urls.select { |url| DeadFinder::UrlPatternMatcher.match?(url, options['match']) }
           end
         rescue RegexpError => e
-          Logger.error "Invalid match pattern: #{e.message}"
+          DeadFinder::Logger.error "Invalid match pattern: #{e.message}"
         end
       end
 
@@ -56,14 +58,14 @@ module DeadFinder
             links[type] = urls.reject { |url| DeadFinder::UrlPatternMatcher.ignore?(url, options['ignore']) }
           end
         rescue RegexpError => e
-          Logger.error "Invalid match pattern: #{e.message}"
+          DeadFinder::Logger.error "Invalid match pattern: #{e.message}"
         end
       end
 
       total_links_count = links.values.flatten.length
       link_info = links.map { |type, urls| "#{type}:#{urls.length}" if urls.length.positive? }
                        .compact.join(' / ')
-      Logger.sub_info "Discovered #{total_links_count} URLs, currently checking them. [#{link_info}]" unless link_info.empty?
+      DeadFinder::Logger.sub_info "Discovered #{total_links_count} URLs, currently checking them. [#{link_info}]" unless link_info.empty?
 
       jobs = Channel.new(buffer: :buffered, capacity: 1000)
       results = Channel.new(buffer: :buffered, capacity: 1000)
@@ -81,9 +83,9 @@ module DeadFinder
       jobs.close
 
       (1..jobs_size).each { ~results }
-      Logger.sub_complete 'Task completed'
+      DeadFinder::Logger.sub_complete 'Task completed'
     rescue StandardError => e
-      Logger.error "[#{e}] #{target}"
+      DeadFinder::Logger.error "[#{e}] #{target}"
     end
 
     def worker(_id, jobs, results, target, options)
@@ -108,15 +110,15 @@ module DeadFinder
             status_code = response.code.to_i
 
             if status_code >= 400 || (status_code >= 300 && options['include30x'])
-              Logger.found "[#{status_code}] #{j}"
+              DeadFinder::Logger.found "[#{status_code}] #{j}"
               CACHE_QUE[j] = false
               DeadFinder.output[target] ||= []
               DeadFinder.output[target] << j
             else
-              Logger.verbose_ok "[#{status_code}] #{j}" if options['verbose']
+              DeadFinder::Logger.verbose_ok "[#{status_code}] #{j}" if options['verbose']
             end
           rescue StandardError => e
-            Logger.verbose "[#{e}] #{j}" if options['verbose']
+            DeadFinder::Logger.verbose "[#{e}] #{j}" if options['verbose']
           end
         end
         results << j

--- a/spec/dead_finder/cli_spec.rb
+++ b/spec/dead_finder/cli_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DeadFinder::CLI do
     allow(DeadFinder).to receive(:run_file)
     allow(DeadFinder).to receive(:run_url)
     allow(DeadFinder).to receive(:run_sitemap)
-    allow(Logger).to receive(:info)
+    allow(DeadFinder::Logger).to receive(:info)
   end
 
   describe '#pipe' do
@@ -45,7 +45,7 @@ RSpec.describe DeadFinder::CLI do
   describe '#version' do
     it 'displays the version' do
       cli.invoke(:version)
-      expect(Logger).to have_received(:info).with("deadfinder #{DeadFinder::VERSION}")
+      expect(DeadFinder::Logger).to have_received(:info).with("deadfinder #{DeadFinder::VERSION}")
     end
   end
 end

--- a/spec/dead_finder/logger_spec.rb
+++ b/spec/dead_finder/logger_spec.rb
@@ -3,11 +3,28 @@
 require_relative '../../lib/deadfinder/logger'
 require 'stringio'
 
-RSpec.describe Logger do
+RSpec.describe DeadFinder::Logger do
   let(:original_stdout) { $stdout }
 
   after do
     $stdout = original_stdout
+  end
+
+  describe '.apply_options' do
+    it 'sets silent mode when options has silent' do
+      expect(described_class).to have_received(:set_silent)
+      described_class.apply_options('silent' => true)
+    end
+
+    it 'sets verbose mode when options has verbose' do
+      expect(described_class).to have_received(:set_verbose)
+      described_class.apply_options('verbose' => true)
+    end
+
+    it 'sets debug mode when options has debug' do
+      expect(described_class).to have_received(:set_debug)
+      described_class.apply_options('debug' => true)
+    end
   end
 
   describe '.silent?' do
@@ -28,6 +45,48 @@ RSpec.describe Logger do
       described_class.set_silent
       described_class.unset_silent
       expect(described_class.silent?).to be false
+    end
+  end
+
+  describe '.verbose?' do
+    it 'returns false by default' do
+      expect(described_class.verbose?).to be false
+    end
+  end
+
+  describe '.set_verbose' do
+    it 'sets the verbose mode to true' do
+      described_class.set_verbose
+      expect(described_class.verbose?).to be true
+    end
+  end
+
+  describe '.unset_verbose' do
+    it 'sets the verbose mode to false' do
+      described_class.set_verbose
+      described_class.unset_verbose
+      expect(described_class.verbose?).to be false
+    end
+  end
+
+  describe '.debug?' do
+    it 'returns false by default' do
+      expect(described_class.debug?).to be false
+    end
+  end
+
+  describe '.set_debug' do
+    it 'sets the debug mode to true' do
+      described_class.set_debug
+      expect(described_class.debug?).to be true
+    end
+  end
+
+  describe '.unset_debug' do
+    it 'sets the debug mode to false' do
+      described_class.set_debug
+      described_class.unset_debug
+      expect(described_class.debug?).to be false
     end
   end
 
@@ -105,6 +164,7 @@ RSpec.describe Logger do
   describe '.verbose' do
     it 'prints verbose message when not in silent mode' do
       described_class.unset_silent
+      described_class.set_verbose
       expect { described_class.verbose('Test verbose') }.to output("\e[0;33;49m  ├── \e[0m\e[0;33;49m➜ \e[0mTest verbose\n").to_stdout
     end
 
@@ -117,6 +177,7 @@ RSpec.describe Logger do
   describe '.verbose_ok' do
     it 'prints verbose_ok message when not in silent mode' do
       described_class.unset_silent
+      described_class.set_verbose
       expect { described_class.verbose_ok('Test verbose_ok') }.to output("\e[0;32;49m  ├── \e[0m\e[0;32;49m✓ \e[0mTest verbose_ok\n").to_stdout
     end
 

--- a/spec/dead_finder/runner_spec.rb
+++ b/spec/dead_finder/runner_spec.rb
@@ -54,24 +54,24 @@ RSpec.describe DeadFinder::Runner do
     context 'with invalid match option' do
       before do
         options['match'] = '[' # Invalid regex pattern
-        allow(Logger).to receive(:error)
+        allow(DeadFinder::Logger).to receive(:error)
       end
 
       it 'logs an error for invalid match pattern' do
         runner.run(target, options)
-        expect(Logger).to have_received(:error).with(/Invalid match pattern/)
+        expect(DeadFinder::Logger).to have_received(:error).with(/Invalid match pattern/)
       end
     end
 
     context 'with invalid ignore option' do
       before do
         options['ignore'] = '[' # Invalid regex pattern
-        allow(Logger).to receive(:error)
+        allow(DeadFinder::Logger).to receive(:error)
       end
 
       it 'logs an error for invalid ignore pattern' do
         runner.run(target, options)
-        expect(Logger).to have_received(:error).with(/Invalid match pattern/)
+        expect(DeadFinder::Logger).to have_received(:error).with(/Invalid match pattern/)
       end
     end
   end


### PR DESCRIPTION
Introduce a `--debug` flag for enhanced logging control and refactor the Logger class to support silent, verbose, and debug modes. Update relevant methods to utilize the new Logger structure.