### PR TITLE
Add --include50x option to CLI and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Commands:
 
 Options:
   r, [--include30x], [--no-include30x]  # Include 30x redirections
+  e, [--include50x], [--no-include50x]  # Include 50x errors
   c, [--concurrency=N]                  # Number of concurrency
                                         # Default: 50
   t, [--timeout=N]                      # Timeout in seconds
@@ -110,10 +111,8 @@ Options:
                                         # Default: json
   H, [--headers=one two three]          # Custom HTTP headers to send with initial request
      [--worker-headers=one two three]   # Custom HTTP headers to send with worker requests
-     [--user-agent=USER_AGENT]          # User-Agent string to use for requests
-                                        # Default: Mozilla/5.0 (compatible; DeadFinder/1.6.1;)
-  p, [--proxy=PROXY]                    # Proxy server to use for requests
-     [--proxy-auth=PROXY_AUTH]          # Proxy server authentication credentials
+     [--user-agent=USER_AGENT]          # User-Agent string to use for requests                                                                                                                      # Default: Mozilla/5.0 (compatible; DeadFinder/1.6.1;)
+  p, [--proxy=PROXY]                    # Proxy server to use for requests                                                                                        [--proxy-auth=PROXY_AUTH]          # Proxy server authentication credentials
   m, [--match=MATCH]                    # Match the URL with the given pattern
   i, [--ignore=IGNORE]                  # Ignore the URL with the given pattern
   s, [--silent], [--no-silent]          # Silent mode

--- a/lib/deadfinder/cli.rb
+++ b/lib/deadfinder/cli.rb
@@ -7,6 +7,7 @@ module DeadFinder
   # CLI class for handling command-line interactions
   class CLI < Thor
     class_option :include30x, aliases: :r, default: false, type: :boolean, desc: 'Include 30x redirections'
+    class_option :include50x, aliases: :e, default: false, type: :boolean, desc: 'Include 50x errors'
     class_option :concurrency, aliases: :c, default: 50, type: :numeric, desc: 'Number of concurrency'
     class_option :timeout, aliases: :t, default: 10, type: :numeric, desc: 'Timeout in seconds'
     class_option :output, aliases: :o, default: '', type: :string, desc: 'File to write result (e.g., json, yaml, csv)'

--- a/lib/deadfinder/runner.rb
+++ b/lib/deadfinder/runner.rb
@@ -23,6 +23,7 @@ module DeadFinder
         'silent' => true,
         'verbose' => false,
         'include30x' => false,
+        'include50x' => false,
         'proxy' => '',
         'proxy_auth' => '',
         'match' => '',
@@ -109,7 +110,7 @@ module DeadFinder
             response = http.request(request)
             status_code = response.code.to_i
 
-            if status_code >= 400 || (status_code >= 300 && options['include30x'])
+            if status_code >= 400 || (status_code >= 300 && options['include30x']) || (status_code >= 500 && options['include50x'])
               DeadFinder::Logger.found "[#{status_code}] #{j}"
               CACHE_QUE[j] = false
               DeadFinder.output[target] ||= []

--- a/spec/deadfinder_spec.rb
+++ b/spec/deadfinder_spec.rb
@@ -102,7 +102,8 @@ RSpec.describe 'DeadFinder' do
         'worker_headers' => [],
         'silent' => true,
         'verbose' => false,
-        'include30x' => false
+        'include30x' => false,
+        'include50x' => false
       )
     end
   end


### PR DESCRIPTION
Introduce a new command-line option to include 50x errors in the CLI, enhancing error handling capabilities. Update the README to reflect this addition.