### PR TITLE
Update DeadFinder to version 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ deadfinder sitemap https://www.hahwul.com/sitemap.xml
 ```yml
 steps:
 - name: Run DeadFinder
-  uses: hahwul/deadfinder@1.6.1
+  uses: hahwul/deadfinder@1.7.0
   # or uses: hahwul/deadfinder@latest
   id: broken-link
   with:
@@ -115,7 +115,7 @@ Options:
   H, [--headers=one two three]          # Custom HTTP headers to send with initial request
      [--worker-headers=one two three]   # Custom HTTP headers to send with worker requests
      [--user-agent=USER_AGENT]          # User-Agent string to use for requests
-                                        # Default: Mozilla/5.0 (compatible; DeadFinder/1.6.1;)
+                                        # Default: Mozilla/5.0 (compatible; DeadFinder/1.7.0;)
   p, [--proxy=PROXY]                    # Proxy server to use for requests
      [--proxy-auth=PROXY_AUTH]          # Proxy server authentication credentials
   m, [--match=MATCH]                    # Match the URL with the given pattern

--- a/github-action/Dockerfile
+++ b/github-action/Dockerfile
@@ -1,5 +1,5 @@
 # Use the deadfinder base image from GitHub Container Registry
-FROM ghcr.io/hahwul/deadfinder:1.6.1
+FROM ghcr.io/hahwul/deadfinder:1.7.0
 
 # Install jq for JSON processing
 RUN apt-get update && apt-get install -y jq

--- a/lib/deadfinder/cli.rb
+++ b/lib/deadfinder/cli.rb
@@ -25,6 +25,10 @@ module DeadFinder
     class_option :verbose, aliases: :v, default: false, type: :boolean, desc: 'Verbose mode'
     class_option :debug, default: false, type: :boolean, desc: 'Debug mode'
 
+    def self.exit_on_failure?
+      true
+    end
+
     desc 'pipe', 'Scan the URLs from STDIN. (e.g., cat urls.txt | deadfinder pipe)'
     def pipe
       DeadFinder.run_pipe options

--- a/lib/deadfinder/cli.rb
+++ b/lib/deadfinder/cli.rb
@@ -15,7 +15,7 @@ module DeadFinder
     class_option :headers, aliases: :H, default: [], type: :array,
                            desc: 'Custom HTTP headers to send with initial request'
     class_option :worker_headers, default: [], type: :array, desc: 'Custom HTTP headers to send with worker requests'
-    class_option :user_agent, default: 'Mozilla/5.0 (compatible; DeadFinder/1.6.1;)', type: :string,
+    class_option :user_agent, default: 'Mozilla/5.0 (compatible; DeadFinder/1.7.0;)', type: :string,
                               desc: 'User-Agent string to use for requests'
     class_option :proxy, aliases: :p, default: '', type: :string, desc: 'Proxy server to use for requests'
     class_option :proxy_auth, default: '', type: :string, desc: 'Proxy server authentication credentials'

--- a/lib/deadfinder/version.rb
+++ b/lib/deadfinder/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeadFinder
-  VERSION = '1.6.1'
+  VERSION = '1.7.0'
 end

--- a/spec/dead_finder/cli_spec.rb
+++ b/spec/dead_finder/cli_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe DeadFinder::CLI do
     allow(DeadFinder::Logger).to receive(:error)
   end
 
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+
   describe '#pipe' do
     it 'runs the pipe command' do
       cli.invoke(:pipe)


### PR DESCRIPTION
Upgrade the DeadFinder dependency to version 1.7.0, updating relevant configurations and default values accordingly.