### PR TITLE
feat: Add --limit flag for file, pipe, and sitemap modes

### DIFF
--- a/lib/deadfinder.rb
+++ b/lib/deadfinder.rb
@@ -49,9 +49,17 @@ module DeadFinder
     base_uri = URI(sitemap_url)
     sitemap = SitemapParser.new(sitemap_url, recurse: true)
     DeadFinder::Logger.info "Found #{sitemap.to_a.size} URLs from #{sitemap_url}"
+    processed_urls = 0
+    limit = options['limit'].to_i
+
     sitemap.to_a.each do |url|
+      if limit > 0 && processed_urls >= limit
+        DeadFinder::Logger.info "Reached URL limit (#{limit}), stopping sitemap processing."
+        break
+      end
       turl = generate_url(url, base_uri)
       run_with_target(turl, options, app)
+      processed_urls += 1
     end
     gen_output(options)
   end
@@ -60,8 +68,16 @@ module DeadFinder
     DeadFinder::Logger.apply_options(options)
     DeadFinder::Logger.info 'Reading input'
     app = Runner.new
+    processed_urls = 0
+    limit = options['limit'].to_i
+
     Array(yield).each do |target|
+      if limit > 0 && processed_urls >= limit
+        DeadFinder::Logger.info "Reached URL limit (#{limit}), stopping."
+        break
+      end
       run_with_target(target, options, app)
+      processed_urls += 1
     end
     gen_output(options)
   end

--- a/lib/deadfinder/cli.rb
+++ b/lib/deadfinder/cli.rb
@@ -9,6 +9,7 @@ module DeadFinder
   class CLI < Thor
     class_option :include30x, aliases: :r, default: false, type: :boolean, desc: 'Include 30x redirections'
     class_option :concurrency, aliases: :c, default: 50, type: :numeric, desc: 'Number of concurrency'
+    class_option :limit, default: 0, type: :numeric, desc: 'Maximum number of URLs to check (0 for no limit)'
     class_option :timeout, aliases: :t, default: 10, type: :numeric, desc: 'Timeout in seconds'
     class_option :output, aliases: :o, default: '', type: :string, desc: 'File to write result (e.g., json, yaml, csv)'
     class_option :output_format, aliases: :f, default: 'json', type: :string, desc: 'Output format'

--- a/spec/dead_finder/cli_spec.rb
+++ b/spec/dead_finder/cli_spec.rb
@@ -2,17 +2,26 @@
 
 require 'spec_helper'
 require 'deadfinder/cli'
+require 'tempfile' # Required for Tempfile
 
 RSpec.describe DeadFinder::CLI do
   let(:cli) { described_class.new }
 
   before do
-    allow(DeadFinder).to receive(:run_pipe)
-    allow(DeadFinder).to receive(:run_file)
-    allow(DeadFinder).to receive(:run_url)
-    allow(DeadFinder).to receive(:run_sitemap)
+    # Allow all original methods by default, we will set expectations on run_with_target
+    allow(DeadFinder).to receive(:run_pipe).and_call_original
+    allow(DeadFinder).to receive(:run_file).and_call_original
+    allow(DeadFinder).to receive(:run_url).and_call_original
+    allow(DeadFinder).to receive(:run_sitemap).and_call_original
+    allow(DeadFinder).to receive(:run_with_target) # This will be our main spy
+    allow(DeadFinder).to receive(:gen_output) # Stub this to prevent file writing during tests
     allow(DeadFinder::Logger).to receive(:info)
     allow(DeadFinder::Logger).to receive(:error)
+    allow(DeadFinder::Logger).to receive(:target)
+    allow(DeadFinder::Logger).to receive(:apply_options)
+
+    # Mock Runner instance and its run method
+    # allow_any_instance_of(DeadFinder::Runner).to receive(:run)
   end
 
   describe '.exit_on_failure?' do
@@ -24,14 +33,58 @@ RSpec.describe DeadFinder::CLI do
   describe '#pipe' do
     it 'runs the pipe command' do
       cli.invoke(:pipe)
-      expect(DeadFinder).to have_received(:run_pipe).with(anything)
+      expect(DeadFinder).to have_received(:run_pipe)
+    end
+
+    context 'with --limit option' do
+      it 'respects the URL limit' do
+        urls = %w[url1 url2 url3 url4 url5]
+        allow($stdin).to receive(:gets).and_return(*urls, nil)
+        # Invoke with options passed directly, as invoke doesn't parse them from ARGV for options hash
+        cli.invoke(:pipe, [], { limit: 2 })
+        expect(DeadFinder).to have_received(:run_with_target).exactly(2).times
+      end
     end
   end
 
   describe '#file' do
+    let(:temp_file) do
+      Tempfile.new('urls.txt').tap do |f|
+        5.times { |i| f.puts "http://example.com/url#{i + 1}" }
+        f.close
+      end
+    end
+    let(:temp_file_path) { temp_file.path }
+
+    after do
+      File.unlink(temp_file_path) if File.exist?(temp_file_path)
+    end
+
     it 'runs the file command with a filename' do
-      cli.invoke(:file, ['urls.txt'])
-      expect(DeadFinder).to have_received(:run_file).with('urls.txt', anything)
+      cli.invoke(:file, [temp_file_path])
+      expect(DeadFinder).to have_received(:run_file).with(temp_file_path, anything)
+      expect(DeadFinder).to have_received(:run_with_target).exactly(5).times
+    end
+
+    context 'with --limit option' do
+      it 'respects the URL limit when limit is set' do
+        # Thor passes options after subcommand args.
+        # The options hash for invoke should be the last argument.
+        # For options like --limit N, it's parsed by Thor into options['limit']
+        cli.invoke(:file, [temp_file_path], { limit: 3 })
+        expect(DeadFinder).to have_received(:run_with_target).exactly(3).times
+      end
+
+      it 'processes all URLs when limit is 0' do
+        cli.invoke(:file, [temp_file_path], { limit: 0 })
+        expect(DeadFinder).to have_received(:run_with_target).exactly(5).times
+      end
+
+      it 'processes all URLs when limit is not specified' do
+        # Simulate no --limit by not passing it in options
+        cli.invoke(:file, [temp_file_path], {}) # Pass empty options or specific options without limit
+        expect(DeadFinder).to have_received(:run_with_target).exactly(5).times
+      end
     end
   end
 
@@ -43,9 +96,36 @@ RSpec.describe DeadFinder::CLI do
   end
 
   describe '#sitemap' do
+    let(:sitemap_url) { 'http://example.com/sitemap.xml' }
+    let(:mock_sitemap_parser) { instance_double(SitemapParser) }
+    let(:sitemap_urls) { Array.new(5) { |i| "http://example.com/sitemap_url#{i + 1}" } }
+
+    before do
+      allow(SitemapParser).to receive(:new).with(sitemap_url, recurse: true).and_return(mock_sitemap_parser)
+      allow(mock_sitemap_parser).to receive(:to_a).and_return(sitemap_urls)
+    end
+
     it 'runs the sitemap command with a sitemap URL' do
-      cli.invoke(:sitemap, ['http://example.com/sitemap.xml'])
-      expect(DeadFinder).to have_received(:run_sitemap).with('http://example.com/sitemap.xml', anything)
+      cli.invoke(:sitemap, [sitemap_url])
+      expect(DeadFinder).to have_received(:run_sitemap).with(sitemap_url, anything)
+      expect(DeadFinder).to have_received(:run_with_target).exactly(5).times
+    end
+
+    context 'with --limit option' do
+      it 'respects the URL limit' do
+        cli.invoke(:sitemap, [sitemap_url], { limit: 4 })
+        expect(DeadFinder).to have_received(:run_with_target).exactly(4).times
+      end
+
+      it 'processes all URLs when limit is 0' do
+        cli.invoke(:sitemap, [sitemap_url], { limit: 0 })
+        expect(DeadFinder).to have_received(:run_with_target).exactly(5).times
+      end
+
+      it 'processes all URLs when limit is not specified' do
+        cli.invoke(:sitemap, [sitemap_url], {})
+        expect(DeadFinder).to have_received(:run_with_target).exactly(5).times
+      end
     end
   end
 


### PR DESCRIPTION
This commit introduces a new `--limit` command-line option that allows you to specify the maximum number of URLs to check when using the `file`, `pipe`, or `sitemap` modes.

The `--limit` option takes an integer value. If the value is greater than 0, DeadFinder will stop processing URLs once the specified limit is reached. A value of 0 (the default) signifies no limit, and all discovered URLs will be checked.

Changes include:
- Added the `--limit` option to `lib/deadfinder/cli.rb`.
- Implemented the limiting logic in `lib/deadfinder.rb` for:
    - `run_with_input` (affecting `file` and `pipe` modes)
    - `run_sitemap` (affecting `sitemap` mode)
- Added comprehensive RSpec tests in `spec/dead_finder/cli_spec.rb` to verify the correct behavior of the `--limit` flag in all three modes, including edge cases like limit 0 or no limit specified.

This addresses issue #84 by providing you with more control over the scope of your scans, especially when dealing with large input sources.