### PR TITLE
Install build and XML dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM ruby:3.4.6-slim
 
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libcurl4-openssl-dev \
+    libxml2-dev \
+    libxslt-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /app
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
```
/usr/local/bundle/gems/ffi-1.17.2-aarch64-linux-gnu/lib/ffi/dynamic_library.rb:94:in 'FFI::DynamicLibrary.load_library': Could not open library 'libcurl': libcurl: cannot open shared object file: No such file or directory. (LoadError)
Could not open library 'libcurl.so': libcurl.so: cannot open shared object file: No such file or directory.
Could not open library 'libcurl.so.4': libcurl.so.4: cannot open shared object file: No such file or directory.
Searched in <system library path>
	from /usr/local/bundle/gems/ffi-1.17.2-aarch64-linux-gnu/lib/ffi/library.rb:95:in 'block in FFI::Library#ffi_lib'
	from /usr/local/bundle/gems/ffi-1.17.2-aarch64-linux-gnu/lib/ffi/library.rb:94:in 'Array#map'
	from /usr/local/bundle/gems/ffi-1.17.2-aarch64-linux-gnu/lib/ffi/library.rb:94:in 'FFI::Library#ffi_l
```

Fix version
```
docker run -it fb63d0e8b3c9322d3354d9a02714ea8b44d2b5620c8380293ce6f5ab76fc1237
Commands:
  deadfinder completion <SHELL>     # Generate completion script for shell.
  deadfinder file <FILE>            # Scan the URLs from File. (e.g., deadfinder file urls.txt)
  deadfinder help [COMMAND]         # Describe available commands or one specific command
  deadfinder pipe                   # Scan the URLs from STDIN. (e.g., cat urls.txt | deadfinder pipe)
  deadfinder sitemap <SITEMAP-URL>  # Scan the URLs from sitemap.
  deadfinder url <URL>              # Scan the Single URL.
  deadfinder version                # Show version.

Options:
  -r, [--include30x], [--no-include30x], [--skip-include30x]  # Include 30x redirections
                                                              # Default: false
```