### PR TITLE
fix(crystal): default silent to false to match Ruby behavior

### DIFF
--- a/crystal/spec/deadfinder/cli_spec.cr
+++ b/crystal/spec/deadfinder/cli_spec.cr
@@ -15,7 +15,7 @@ describe Deadfinder::CLI do
       options.output_format.should eq "json"
       options.headers.should eq [] of String
       options.worker_headers.should eq [] of String
-      options.silent.should be_true
+      options.silent.should be_false
       options.verbose.should be_false
       options.debug.should be_false
       options.include30x.should be_false

--- a/crystal/src/deadfinder/types.cr
+++ b/crystal/src/deadfinder/types.cr
@@ -6,7 +6,7 @@ module Deadfinder
     property output_format : String = "json"
     property headers : Array(String) = [] of String
     property worker_headers : Array(String) = [] of String
-    property silent : Bool = true
+    property silent : Bool = false
     property verbose : Bool = false
     property debug : Bool = false
     property include30x : Bool = false


### PR DESCRIPTION
## Summary
- Crystal 포팅 버전의 `silent` 기본값이 `true`였고, `-s` 플래그도 `silent = true`로 설정하는 구조라 사실상 no-op였다. 결과적으로 Crystal 바이너리 사용자는 기본 실행 시 아무 로그도 보지 못했다.
- Ruby 구현과 동일하게 `false`로 기본값을 맞춰 행동 회귀를 제거한다.

## 배경
#201 Feature Parity 분석에서 발견된 **GAP-1**. 마이그레이션 중 사용자 워크플로우 호환성 유지를 위한 선행 핫픽스.

- Ruby: `lib/deadfinder/cli.rb` — `option :silent, default: false`
- Crystal (변경 전): `crystal/src/deadfinder/types.cr:9` — `property silent : Bool = true`
- `crystal/src/deadfinder/cli.cr:36` — `parser.on("-s", ...) { options.silent = true }`

## Test plan
- [ ] CI green (Crystal spec 포함)
- [ ] `options.silent` 기본값 false로 단언하는 spec 갱신됨 (`crystal/spec/deadfinder/cli_spec.cr:18`)
- [ ] (리뷰어 확인 권장) 수동: Crystal 바이너리 빌드 후 `deadfinder url https://example.com` 실행 시 로그 출력됨