### PR TITLE
test(compat): add cross-implementation compatibility harness

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -1,0 +1,38 @@
+---
+name: Compat Tests
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  compat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '4.0'
+          bundler-cache: true
+
+      - name: Set up Crystal
+        uses: crystal-lang/install-crystal@v1
+
+      - name: Install cmake (for lexbor)
+        run: sudo apt-get update && sudo apt-get install -y cmake
+
+      - name: Build Crystal binary
+        working-directory: crystal
+        run: |
+          shards install
+          crystal build src/cli_main.cr -o deadfinder --release
+
+      - name: Compat — Ruby implementation
+        run: bundle exec ruby spec/compat/run.rb
+
+      - name: Compat — Crystal implementation
+        env:
+          BIN: ./crystal/deadfinder
+        run: bundle exec ruby spec/compat/run.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ AllCops:
     - "Gemfile*"
     - "lib/deadfinder/runner.rb"
     - "examples/**/*"
+    - "spec/compat/**/*" # black-box compat harness (not RSpec)
     - "vendor/bundle/**/*" # Add this line to exclude vendor/bundle directory
   SuggestExtensions: false
 

--- a/spec/compat/README.md
+++ b/spec/compat/README.md
@@ -1,0 +1,39 @@
+# Cross-implementation compatibility harness
+
+이 디렉토리는 Ruby 원본과 Crystal 포팅 구현이 **사용자에게 동일한 출력을 낸다**는 것을 검증하는 블랙박스 테스트다.
+
+## 구조
+
+```
+spec/compat/
+├── fixtures/
+│   └── server.rb         # 최소 HTTP fixture 서버 (stdlib only)
+├── golden/
+│   └── <case>.json       # 기대 출력. {{BASE}} 플레이스홀더 사용
+├── run.rb                # 드라이버: 서버 기동 → 바이너리 실행 → 비교
+└── README.md
+```
+
+## 실행
+
+```bash
+# 기본: Ruby 구현
+ruby spec/compat/run.rb
+
+# Crystal 구현
+cd crystal && shards install && crystal build src/cli_main.cr -o deadfinder --release
+cd ..
+BIN="./crystal/deadfinder" ruby spec/compat/run.rb
+```
+
+## 케이스 추가
+
+1. `fixtures/server.rb`의 `ROUTES`에 필요한 경로 추가
+2. `golden/<name>.json`에 기대 출력 작성 (`{{BASE}}`로 origin 표현)
+3. `run.rb` 맨 아래 `run_case(...)` 한 줄 추가
+
+## 비교 규칙
+
+- 배열은 정렬 후 비교 (링크 추출 순서 비결정성 흡수)
+- `{{BASE}}` 플레이스홀더는 실행 시 동적 포트로 치환
+- 출력은 `-o <tmpfile>`로 받아 파일에서 파싱 (stdout에는 구조화 출력 없음)

--- a/spec/compat/fixtures/server.rb
+++ b/spec/compat/fixtures/server.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'socket'
+
+ROUTES = {
+  '/index.html' => {
+    status: 200,
+    content_type: 'text/html',
+    body: <<~HTML
+      <!DOCTYPE html>
+      <html><body>
+      <a href="ok">ok</a>
+      <a href="dead">dead</a>
+      <a href="redirect">redirect</a>
+      </body></html>
+    HTML
+  },
+  '/ok'       => { status: 200, content_type: 'text/plain', body: 'OK' },
+  '/dead'     => { status: 404, content_type: 'text/plain', body: 'Not Found' },
+  '/redirect' => { status: 301, content_type: 'text/plain', body: '', extra: { 'Location' => '/ok' } }
+}.freeze
+
+STATUS_TEXT = { 200 => 'OK', 301 => 'Moved Permanently', 404 => 'Not Found' }.freeze
+
+server = TCPServer.new('127.0.0.1', 0)
+puts server.addr[1]
+STDOUT.flush
+
+trap('TERM') { exit 0 }
+trap('INT')  { exit 0 }
+
+loop do
+  client = server.accept
+  begin
+    request_line = client.gets
+    raw_path = request_line&.split(' ')&.dig(1) || '/'
+    path = raw_path.split('?').first
+    while (line = client.gets) && line.strip != ''; end
+
+    route = ROUTES[path]
+    if route
+      headers = {
+        'Content-Type'   => route[:content_type],
+        'Content-Length' => route[:body].bytesize.to_s
+      }.merge(route[:extra] || {})
+      client.print "HTTP/1.1 #{route[:status]} #{STATUS_TEXT[route[:status]] || 'OK'}\r\n"
+      headers.each { |k, v| client.print "#{k}: #{v}\r\n" }
+      client.print "\r\n#{route[:body]}"
+    else
+      client.print "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"
+    end
+  rescue StandardError
+    # swallow: test fixture, keep accepting
+  ensure
+    client&.close
+  end
+end

--- a/spec/compat/golden/file_json.json
+++ b/spec/compat/golden/file_json.json
@@ -1,0 +1,5 @@
+{
+  "{{BASE}}/index.html": [
+    "{{BASE}}/dead"
+  ]
+}

--- a/spec/compat/golden/pipe_json.json
+++ b/spec/compat/golden/pipe_json.json
@@ -1,0 +1,5 @@
+{
+  "{{BASE}}/index.html": [
+    "{{BASE}}/dead"
+  ]
+}

--- a/spec/compat/golden/url_csv.csv
+++ b/spec/compat/golden/url_csv.csv
@@ -1,0 +1,2 @@
+target,url
+{{BASE}}/index.html,{{BASE}}/dead

--- a/spec/compat/golden/url_json.json
+++ b/spec/compat/golden/url_json.json
@@ -1,0 +1,5 @@
+{
+  "{{BASE}}/index.html": [
+    "{{BASE}}/dead"
+  ]
+}

--- a/spec/compat/golden/url_json_include30x.json
+++ b/spec/compat/golden/url_json_include30x.json
@@ -1,0 +1,6 @@
+{
+  "{{BASE}}/index.html": [
+    "{{BASE}}/dead",
+    "{{BASE}}/redirect"
+  ]
+}

--- a/spec/compat/golden/url_toml.toml
+++ b/spec/compat/golden/url_toml.toml
@@ -1,0 +1,1 @@
+"{{BASE}}/index.html" = ["{{BASE}}/dead"]

--- a/spec/compat/golden/url_yaml.yaml
+++ b/spec/compat/golden/url_yaml.yaml
@@ -1,0 +1,3 @@
+---
+{{BASE}}/index.html:
+- {{BASE}}/dead

--- a/spec/compat/run.rb
+++ b/spec/compat/run.rb
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Cross-implementation compatibility harness.
+#
+# Runs the deadfinder binary under test against a local fixture server,
+# writes the output to a temp file (deadfinder only serializes to file),
+# and compares to a golden file. Golden files use the `{{BASE}}` placeholder
+# for the dynamic fixture server origin.
+#
+# Usage:
+#   ruby spec/compat/run.rb                   # uses the repo's Ruby binary
+#   BIN="./crystal/deadfinder" ruby spec/compat/run.rb
+
+require 'json'
+require 'open3'
+require 'tempfile'
+
+REPO_ROOT    = File.expand_path('../..', __dir__)
+HARNESS_ROOT = __dir__
+DEFAULT_BIN  = "ruby -I #{REPO_ROOT}/lib #{REPO_ROOT}/bin/deadfinder"
+
+BIN = ENV.fetch('BIN', DEFAULT_BIN)
+
+def sort_arrays(obj)
+  case obj
+  when Hash  then obj.transform_values { |v| sort_arrays(v) }
+  when Array then obj.map { |v| sort_arrays(v) }.sort_by(&:to_s)
+  else obj
+  end
+end
+
+def run_case(base, name, args, golden_path)
+  Tempfile.create(['deadfinder', '.json']) do |tmp|
+    cmd = "#{BIN} #{args.gsub('{{BASE}}', base)} -o #{tmp.path} -s"
+    stdout, stderr, status = Open3.capture3(cmd)
+    unless status.success?
+      warn "FAIL: #{name} — exit #{status.exitstatus}"
+      warn "CMD:     #{cmd}"
+      warn "STDOUT:  #{stdout}"
+      warn "STDERR:  #{stderr}"
+      return false
+    end
+
+    expected = JSON.parse(File.read(golden_path).gsub('{{BASE}}', base))
+    actual   = JSON.parse(File.read(tmp.path))
+
+    if sort_arrays(actual) == sort_arrays(expected)
+      puts "PASS: #{name}"
+      true
+    else
+      warn "FAIL: #{name}"
+      warn "EXPECTED: #{JSON.pretty_generate(expected)}"
+      warn "ACTUAL:   #{JSON.pretty_generate(actual)}"
+      false
+    end
+  end
+end
+
+server_io = IO.popen(['ruby', "#{HARNESS_ROOT}/fixtures/server.rb"], 'r')
+port = server_io.gets&.strip
+abort 'fixture server did not start' unless port && !port.empty?
+base = "http://127.0.0.1:#{port}"
+
+at_exit do
+  begin
+    Process.kill('TERM', server_io.pid)
+  rescue Errno::ESRCH
+    # already gone
+  end
+end
+
+all_pass = true
+all_pass &= run_case(base, 'url_json',
+                     'url {{BASE}}/index.html -f json',
+                     "#{HARNESS_ROOT}/golden/url_json.json")
+
+exit(all_pass ? 0 : 1)

--- a/spec/compat/run.rb
+++ b/spec/compat/run.rb
@@ -67,13 +67,16 @@ def run_case(base, name:, args:, format:, golden:, stdin: nil, extra_files: {})
     end
 
     expected_text = substitute_base(File.read(golden), base)
-    expected_path = Tempfile.new(['expected', ".#{format}"]).tap { |f| f.write(expected_text); f.close }.path
+    expected_path = Tempfile.new(['expected', ".#{format}"]).tap do |f|
+      f.write(expected_text)
+      f.close
+    end.path
 
     expected = parse_output(expected_path, format)
     actual   = parse_output(tmp.path, format)
 
     if sort_arrays(actual) == sort_arrays(expected)
-      puts "PASS: #{name}"
+
       true
     else
       warn "FAIL: #{name}"
@@ -83,7 +86,7 @@ def run_case(base, name:, args:, format:, golden:, stdin: nil, extra_files: {})
     end
   end
 ensure
-  extra_files.each_key { |path| File.delete(path) if File.exist?(path) }
+  extra_files.each_key { |path| FileUtils.rm_f(path) }
 end
 
 # --- Boot fixture server ----------------------------------------------------
@@ -93,11 +96,9 @@ abort 'fixture server did not start' unless port && !port.empty?
 base = "http://127.0.0.1:#{port}"
 
 at_exit do
-  begin
-    Process.kill('TERM', server_io.pid)
-  rescue Errno::ESRCH
-    # already gone
-  end
+  Process.kill('TERM', server_io.pid)
+rescue Errno::ESRCH
+  # already gone
 end
 
 # --- Cases ------------------------------------------------------------------
@@ -106,47 +107,47 @@ urls_file = File.join(Dir.tmpdir, "deadfinder_compat_urls_#{Process.pid}.txt")
 results = []
 
 results << run_case(base,
-                    name:   'url_json',
-                    args:   'url {{BASE}}/index.html',
+                    name: 'url_json',
+                    args: 'url {{BASE}}/index.html',
                     format: 'json',
                     golden: "#{HARNESS_ROOT}/golden/url_json.json")
 
 results << run_case(base,
-                    name:   'url_yaml',
-                    args:   'url {{BASE}}/index.html',
+                    name: 'url_yaml',
+                    args: 'url {{BASE}}/index.html',
                     format: 'yaml',
                     golden: "#{HARNESS_ROOT}/golden/url_yaml.yaml")
 
 results << run_case(base,
-                    name:   'url_toml',
-                    args:   'url {{BASE}}/index.html',
+                    name: 'url_toml',
+                    args: 'url {{BASE}}/index.html',
                     format: 'toml',
                     golden: "#{HARNESS_ROOT}/golden/url_toml.toml")
 
 results << run_case(base,
-                    name:   'url_csv',
-                    args:   'url {{BASE}}/index.html',
+                    name: 'url_csv',
+                    args: 'url {{BASE}}/index.html',
                     format: 'csv',
                     golden: "#{HARNESS_ROOT}/golden/url_csv.csv")
 
 results << run_case(base,
-                    name:   'url_json_include30x',
-                    args:   'url {{BASE}}/index.html -r',
+                    name: 'url_json_include30x',
+                    args: 'url {{BASE}}/index.html -r',
                     format: 'json',
                     golden: "#{HARNESS_ROOT}/golden/url_json_include30x.json")
 
 results << run_case(base,
-                    name:         'file_json',
-                    args:         "file #{urls_file}",
-                    format:       'json',
-                    golden:       "#{HARNESS_ROOT}/golden/file_json.json",
-                    extra_files:  { urls_file => "{{BASE}}/index.html\n" })
+                    name: 'file_json',
+                    args: "file #{urls_file}",
+                    format: 'json',
+                    golden: "#{HARNESS_ROOT}/golden/file_json.json",
+                    extra_files: { urls_file => "{{BASE}}/index.html\n" })
 
 results << run_case(base,
-                    name:   'pipe_json',
-                    args:   'pipe',
+                    name: 'pipe_json',
+                    args: 'pipe',
                     format: 'json',
                     golden: "#{HARNESS_ROOT}/golden/pipe_json.json",
-                    stdin:  substitute_base("{{BASE}}/index.html\n", base))
+                    stdin: substitute_base("{{BASE}}/index.html\n", base))
 
 exit(results.all? ? 0 : 1)

--- a/spec/compat/run.rb
+++ b/spec/compat/run.rb
@@ -12,9 +12,12 @@
 #   ruby spec/compat/run.rb                   # uses the repo's Ruby binary
 #   BIN="./crystal/deadfinder" ruby spec/compat/run.rb
 
+require 'csv'
 require 'json'
 require 'open3'
 require 'tempfile'
+require 'toml-rb'
+require 'yaml'
 
 REPO_ROOT    = File.expand_path('../..', __dir__)
 HARNESS_ROOT = __dir__
@@ -30,33 +33,60 @@ def sort_arrays(obj)
   end
 end
 
-def run_case(base, name, args, golden_path)
-  Tempfile.create(['deadfinder', '.json']) do |tmp|
-    cmd = "#{BIN} #{args.gsub('{{BASE}}', base)} -o #{tmp.path} -s"
-    stdout, stderr, status = Open3.capture3(cmd)
+def parse_output(path, format)
+  text = File.read(path)
+  case format
+  when 'json'        then JSON.parse(text)
+  when 'yaml', 'yml' then YAML.safe_load(text)
+  when 'toml'        then TomlRB.parse(text)
+  when 'csv'         then CSV.parse(text)
+  else raise "unknown format: #{format}"
+  end
+end
+
+def substitute_base(text, base)
+  text.gsub('{{BASE}}', base)
+end
+
+def run_case(base, name:, args:, format:, golden:, stdin: nil, extra_files: {})
+  extra_files.each do |path, content|
+    File.write(path, substitute_base(content, base))
+  end
+
+  Tempfile.create(['deadfinder', ".#{format}"]) do |tmp|
+    resolved_args = substitute_base(args, base)
+    cmd = "#{BIN} #{resolved_args} -o #{tmp.path} -f #{format} -s"
+    stdout, stderr, status = Open3.capture3(cmd, stdin_data: stdin || '')
+
     unless status.success?
       warn "FAIL: #{name} — exit #{status.exitstatus}"
-      warn "CMD:     #{cmd}"
-      warn "STDOUT:  #{stdout}"
-      warn "STDERR:  #{stderr}"
+      warn "CMD:    #{cmd}"
+      warn "STDOUT: #{stdout}"
+      warn "STDERR: #{stderr}"
       return false
     end
 
-    expected = JSON.parse(File.read(golden_path).gsub('{{BASE}}', base))
-    actual   = JSON.parse(File.read(tmp.path))
+    expected_text = substitute_base(File.read(golden), base)
+    expected_path = Tempfile.new(['expected', ".#{format}"]).tap { |f| f.write(expected_text); f.close }.path
+
+    expected = parse_output(expected_path, format)
+    actual   = parse_output(tmp.path, format)
 
     if sort_arrays(actual) == sort_arrays(expected)
       puts "PASS: #{name}"
       true
     else
       warn "FAIL: #{name}"
-      warn "EXPECTED: #{JSON.pretty_generate(expected)}"
-      warn "ACTUAL:   #{JSON.pretty_generate(actual)}"
+      warn "EXPECTED: #{expected.inspect}"
+      warn "ACTUAL:   #{actual.inspect}"
       false
     end
   end
+ensure
+  extra_files.each_key { |path| File.delete(path) if File.exist?(path) }
 end
 
+# --- Boot fixture server ----------------------------------------------------
 server_io = IO.popen(['ruby', "#{HARNESS_ROOT}/fixtures/server.rb"], 'r')
 port = server_io.gets&.strip
 abort 'fixture server did not start' unless port && !port.empty?
@@ -70,9 +100,53 @@ at_exit do
   end
 end
 
-all_pass = true
-all_pass &= run_case(base, 'url_json',
-                     'url {{BASE}}/index.html -f json',
-                     "#{HARNESS_ROOT}/golden/url_json.json")
+# --- Cases ------------------------------------------------------------------
+urls_file = File.join(Dir.tmpdir, "deadfinder_compat_urls_#{Process.pid}.txt")
 
-exit(all_pass ? 0 : 1)
+results = []
+
+results << run_case(base,
+                    name:   'url_json',
+                    args:   'url {{BASE}}/index.html',
+                    format: 'json',
+                    golden: "#{HARNESS_ROOT}/golden/url_json.json")
+
+results << run_case(base,
+                    name:   'url_yaml',
+                    args:   'url {{BASE}}/index.html',
+                    format: 'yaml',
+                    golden: "#{HARNESS_ROOT}/golden/url_yaml.yaml")
+
+results << run_case(base,
+                    name:   'url_toml',
+                    args:   'url {{BASE}}/index.html',
+                    format: 'toml',
+                    golden: "#{HARNESS_ROOT}/golden/url_toml.toml")
+
+results << run_case(base,
+                    name:   'url_csv',
+                    args:   'url {{BASE}}/index.html',
+                    format: 'csv',
+                    golden: "#{HARNESS_ROOT}/golden/url_csv.csv")
+
+results << run_case(base,
+                    name:   'url_json_include30x',
+                    args:   'url {{BASE}}/index.html -r',
+                    format: 'json',
+                    golden: "#{HARNESS_ROOT}/golden/url_json_include30x.json")
+
+results << run_case(base,
+                    name:         'file_json',
+                    args:         "file #{urls_file}",
+                    format:       'json',
+                    golden:       "#{HARNESS_ROOT}/golden/file_json.json",
+                    extra_files:  { urls_file => "{{BASE}}/index.html\n" })
+
+results << run_case(base,
+                    name:   'pipe_json',
+                    args:   'pipe',
+                    format: 'json',
+                    golden: "#{HARNESS_ROOT}/golden/pipe_json.json",
+                    stdin:  substitute_base("{{BASE}}/index.html\n", base))
+
+exit(results.all? ? 0 : 1)


### PR DESCRIPTION
## Summary
- Ruby 원본과 Crystal 포팅이 **동일 입력에 대해 동일 출력을 낸다**는 것을 CI에서 검증하는 블랙박스 하네스를 추가한다.
- 이번 PR은 **MVP 1케이스** (url × json)만 포함하고, 이후 포맷/서브커맨드 케이스는 follow-up PR로 확장한다.

## 설계
- `spec/compat/fixtures/server.rb` — stdlib only 최소 HTTP 서버. 랜덤 포트에 바인딩 후 stdout으로 포트 출력
- `spec/compat/golden/*.json` — 기대 출력. 동적 origin은 `{{BASE}}` 플레이스홀더
- `spec/compat/run.rb` — 드라이버. 서버 기동 → 바이너리 실행(`-o tmpfile`) → 정렬 후 비교
- `.github/workflows/compat.yml` — Ruby + Crystal 양쪽 실행

출력은 `-o` 파일로만 구조화되므로(stdout은 로그만) temp 파일을 사용한다.

## 배경
#202의 첫 단계. 전략은 #201 코멘트의 매트릭스 기반으로 **C안 (하이브리드)** 채택.

## 확장 방법
케이스 추가 시:
1. `fixtures/server.rb`의 `ROUTES`에 경로 추가
2. `golden/<name>.json` 작성 (`{{BASE}}` 플레이스홀더 사용)
3. `run.rb` 맨 아래 `run_case(...)` 한 줄 추가

## 알아둘 점 (이번 PR 범위 밖)
하네스 작성 중 `lib/deadfinder/utils.rb:14`에서 **절대 경로(`/path`) 해석 시 base URL의 포트를 떨어뜨리는 버그**를 발견했다. 포팅 Crystal 구현도 동일하게 버그가 있어 호환성 테스트상 문제는 아니지만, 별도 이슈로 추적이 필요하다. 현재 fixture는 이 경로를 피해 상대 경로를 쓰고 있음.

## Test plan
- [x] 로컬: `bundle exec ruby spec/compat/run.rb` 통과
- [ ] CI: Ruby 구현 케이스 통과
- [ ] CI: Crystal 구현 케이스 통과 (빌드 + 동일 golden 매칭)
- [ ] (리뷰어 확인) 하네스 구조가 확장 가능한지