### PR TITLE
ci: add Crystal multi-platform release build workflow

### DIFF
--- a/.github/workflows/crystal-release.yml
+++ b/.github/workflows/crystal-release.yml
@@ -1,0 +1,100 @@
+---
+name: Crystal Release Builds
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runs-on: ubuntu-latest
+          - arch: aarch64
+            runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build static binary (Alpine / musl)
+        run: |
+          docker run --rm -v "$PWD":/workspace -w /workspace/crystal \
+            crystallang/crystal:latest-alpine \
+            sh -c 'apk add --no-cache cmake make g++ \
+                   && shards install \
+                   && crystal build src/cli_main.cr -o deadfinder --release --static --no-debug'
+
+      - name: Package
+        run: |
+          cd crystal
+          chmod +x deadfinder
+          tar czf ../deadfinder-linux-${{ matrix.arch }}.tar.gz deadfinder
+          cd ..
+          sha256sum deadfinder-linux-${{ matrix.arch }}.tar.gz > deadfinder-linux-${{ matrix.arch }}.tar.gz.sha256
+
+      - name: Upload to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            deadfinder-linux-${{ matrix.arch }}.tar.gz
+            deadfinder-linux-${{ matrix.arch }}.tar.gz.sha256
+
+      - name: Upload as workflow artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
+        with:
+          name: deadfinder-linux-${{ matrix.arch }}
+          path: |
+            deadfinder-linux-${{ matrix.arch }}.tar.gz
+            deadfinder-linux-${{ matrix.arch }}.tar.gz.sha256
+
+  build-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runs-on: macos-latest
+          - arch: x86_64
+            runs-on: macos-13
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Crystal and cmake
+        run: brew install crystal cmake
+
+      - name: Build release binary
+        working-directory: crystal
+        run: |
+          shards install
+          crystal build src/cli_main.cr -o deadfinder --release --no-debug
+
+      - name: Package
+        run: |
+          cd crystal
+          chmod +x deadfinder
+          tar czf ../deadfinder-macos-${{ matrix.arch }}.tar.gz deadfinder
+          cd ..
+          shasum -a 256 deadfinder-macos-${{ matrix.arch }}.tar.gz > deadfinder-macos-${{ matrix.arch }}.tar.gz.sha256
+
+      - name: Upload to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            deadfinder-macos-${{ matrix.arch }}.tar.gz
+            deadfinder-macos-${{ matrix.arch }}.tar.gz.sha256
+
+      - name: Upload as workflow artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
+        with:
+          name: deadfinder-macos-${{ matrix.arch }}
+          path: |
+            deadfinder-macos-${{ matrix.arch }}.tar.gz
+            deadfinder-macos-${{ matrix.arch }}.tar.gz.sha256

--- a/.github/workflows/crystal-release.yml
+++ b/.github/workflows/crystal-release.yml
@@ -5,6 +5,12 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
+env:
+  CRYSTAL_BUILD_IMAGE: crystallang/crystal:1.19.1-alpine
+
 jobs:
   build-linux:
     strategy:
@@ -22,7 +28,7 @@ jobs:
       - name: Build static binary (Alpine / musl)
         run: |
           docker run --rm -v "$PWD":/workspace -w /workspace/crystal \
-            crystallang/crystal:latest-alpine \
+            ${{ env.CRYSTAL_BUILD_IMAGE }} \
             sh -c 'apk add --no-cache cmake make g++ \
                    && shards install \
                    && crystal build src/cli_main.cr -o deadfinder --release --static --no-debug'


### PR DESCRIPTION
## Summary
- Release 태그 발행 시 Crystal 바이너리를 자동으로 멀티 플랫폼 빌드해 Release 자산으로 첨부한다.
- workflow_dispatch로 수동 트리거 가능 → 실제 릴리스 전에 파이프라인 검증용

## 대상 플랫폼
| OS | Arch | Runner | 링크 방식 |
|---|---|---|---|
| Linux | x86_64 | ubuntu-latest | **static (musl/Alpine 컨테이너)** |
| Linux | aarch64 | ubuntu-24.04-arm | **static (musl/Alpine 컨테이너)** |
| macOS | arm64 | macos-latest | dynamic (Homebrew Crystal) |
| macOS | x86_64 | macos-13 | dynamic (Homebrew Crystal) |

Linux는 static으로 빌드해 glibc 버전 의존 없이 배포한다. macOS는 OS별 툴체인 관행에 따라 dynamic.

## 산출물
- `deadfinder-{os}-{arch}.tar.gz`
- `deadfinder-{os}-{arch}.tar.gz.sha256`

## 이번 PR 범위 밖
- **Windows**: Crystal의 Windows 공식 지원이 아직 실험적. 이후 별도 PR에서 검토
- **Homebrew formula 업데이트**: #206에서 이 릴리스 자산을 소비하도록 전환
- **Docker/Action 전환**: #204/#205

## 배경
#209 (Tracking) → #203. #211 (compat 하네스)가 머지되면 이 빌드 자산이 호환성 보장을 받게 된다.

## Test plan
- [ ] PR 대상으로 `workflow_dispatch` 수동 실행 → Linux x86_64 artifact 생성 확인
- [ ] Linux aarch64 빌드 성공 (ubuntu-24.04-arm runner 사용 가능 여부)
- [ ] macOS arm64 빌드 성공
- [ ] macOS x86_64 빌드 성공 (macos-13 EOL 고려 필요할 수 있음)
- [ ] (머지 후) 테스트 태그로 release 이벤트 트리거해 자산 업로드 검증