### PR TITLE
fix(crystal): preserve port when resolving relative and absolute URLs

### DIFF
--- a/crystal/spec/deadfinder/utils_spec.cr
+++ b/crystal/spec/deadfinder/utils_spec.cr
@@ -62,6 +62,18 @@ describe "Deadfinder.generate_url" do
   it "handles root-relative paths" do
     Deadfinder.generate_url("/about", "https://example.com/some/deep/path").should eq "https://example.com/about"
   end
+
+  it "preserves non-default port when resolving root-relative paths" do
+    Deadfinder.generate_url("/about", "http://127.0.0.1:8080/index.html").should eq "http://127.0.0.1:8080/about"
+  end
+
+  it "preserves non-default port when resolving relative paths" do
+    Deadfinder.generate_url("about", "http://127.0.0.1:8080/index.html").should eq "http://127.0.0.1:8080/about"
+  end
+
+  it "preserves non-default port when base path is a directory" do
+    Deadfinder.generate_url("page.html", "http://127.0.0.1:8080/dir/").should eq "http://127.0.0.1:8080/dir/page.html"
+  end
 end
 
 describe "Deadfinder.ignore_scheme?" do

--- a/crystal/src/deadfinder/utils.cr
+++ b/crystal/src/deadfinder/utils.cr
@@ -16,7 +16,7 @@ module Deadfinder
       if node.starts_with?("//")
         "#{uri.scheme}:#{node}"
       elsif node.starts_with?("/")
-        "#{uri.scheme}://#{uri.host}#{node}"
+        "#{origin(uri)}#{node}"
       elsif ignore_scheme?(node)
         nil
       else
@@ -25,6 +25,14 @@ module Deadfinder
       end
     rescue
       nil
+    end
+  end
+
+  private def self.origin(uri : URI) : String
+    if port = uri.port
+      "#{uri.scheme}://#{uri.host}:#{port}"
+    else
+      "#{uri.scheme}://#{uri.host}"
     end
   end
 
@@ -45,7 +53,7 @@ module Deadfinder
           resolved_path = "/" + relative
         end
       end
-      "#{base_uri.scheme}://#{base_uri.host}#{resolved_path}"
+      "#{origin(base_uri)}#{resolved_path}"
     rescue
       nil
     end


### PR DESCRIPTION
## Summary
`generate_url` / `resolve_relative_url`이 resolved origin을 `"#{scheme}://#{host}#{path}"`로 만들어서 non-default 포트를 떨어뜨린다. 80/443 외의 포트에서 서비스되는 페이지에 `href="/path"`나 `href="relative/path"`가 있을 때 포트가 빠진 URL이 나와서 다른 origin을 치거나 연결 실패한다.

## 변경
- `origin(uri)` 헬퍼 추가 — `URI#port`가 세팅되어 있으면 `:port` 붙여서 origin 문자열 구성
- 두 resolution 경로 모두 이 헬퍼 경유
- `crystal/spec/deadfinder/utils_spec.cr`에 포트 보존 케이스 3개 추가 (`/path`, `relative`, trailing-slash base)

## 배경
#202 compat 하네스 작성 중 발견. fixture 서버가 랜덤 포트에 바인딩되므로 이 버그 때문에 Crystal 쪽 케이스 7개 전부 실패 (`{}` 반환)했다. 이 PR 머지 후 #211의 Crystal compat 단계가 녹색으로 돌아와야 한다.

관련: Ruby 구현 `lib/deadfinder/utils.rb:14`의 `/path` 분기도 동일한 포트 누락 문제가 있음. 다만 Ruby는 상대 경로 분기에서 `URI.join`을 쓰기 때문에 대부분의 실제 링크에서는 증상이 덜 드러남. 별도 PR로 추적 예정.

## Test plan
- [x] 로컬: 신규 spec 3개 통과 (crystal/spec/deadfinder/utils_spec.cr)
- [ ] CI: crystal spec 전체 통과
- [ ] 머지 후: #211 compat 하네스의 Crystal 단계 녹색