### PR TITLE
ci(docker): OCI labels, semver tags, cosign signing, native arm64

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,29 +10,28 @@ on:
 
 jobs:
   build-docker:
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        arch: [linux/amd64, linux/arm64]
+        include:
+          - arch: linux/amd64
+            runner: ubuntu-latest
+          - arch: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v4.1.1
-        with:
-          cosign-release: v2.1.1
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+      - uses: actions/checkout@v6
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v4
+      - name: Prepare platform slug
+        id: platform
+        run: echo "slug=$(echo '${{ matrix.arch }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
       - name: Build Docker image
-        id: build-and-push
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -40,5 +39,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.arch }}
-          cache-from: type=gha,scope=${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+          cache-from: type=gha,scope=build-${{ steps.platform.outputs.slug }}
+          cache-to: type=gha,mode=max,scope=build-${{ steps.platform.outputs.slug }}

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,79 +1,154 @@
 ---
 name: GHCR Publish
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
 on:
   push:
     branches: [main]
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      version:
+        description: Version to build and tag (e.g., 2.0.0)
+        required: true
+        type: string
 
 env:
-  # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v4.1.1
-        with:
-          cosign-release: v2.1.1
-
-      # Using QEME for multiple platforms
-      # https://github.com/docker/build-push-action?tab=readme-ov-file#usage
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@v3
 
-      # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v3
 
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
+      - name: Log into ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v7
+      - name: Prepare platform slug
+        id: platform
+        run: echo "slug=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64, linux/arm64
-          cache-from: type=gha,scope=${{ github.sha }}
-          cache-to: type=gha,mode=max,scope=${{ github.sha }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=ghcr-${{ steps.platform.outputs.slug }}
+          cache-to: type=gha,mode=max,scope=ghcr-${{ steps.platform.outputs.slug }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.platform.outputs.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.0.0
+        with:
+          cosign-release: v2.1.1
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Normalize dispatch version
+        if: github.event_name == 'workflow_dispatch'
+        id: normalize
+        run: |
+          RAW_VERSION="${{ inputs.version }}"
+          VERSION="${RAW_VERSION#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Extract Docker metadata (tags)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=${{ steps.normalize.outputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+      - name: Sign the published image with cosign (keyless)
+        if: github.event_name != 'pull_request'
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.meta.outputs.version }}
+        run: |
+          # Re-resolve the digest for each published tag and sign it.
+          for tag in $TAGS; do
+            digest=$(docker buildx imagetools inspect "$tag" --raw | sha256sum | awk '{print $1}')
+            echo "Signing ${tag}@sha256:${digest}"
+            cosign sign --yes "${tag}@sha256:${digest}"
+          done

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,21 @@ RUN shards install
 RUN crystal build src/cli_main.cr -o /build/deadfinder --release --static --no-debug
 
 FROM alpine:3.21
+
+LABEL org.opencontainers.image.title="DeadFinder"
+LABEL org.opencontainers.image.description="Find dead links (broken links)."
+LABEL org.opencontainers.image.authors="HAHWUL <hahwul@gmail.com>"
+LABEL org.opencontainers.image.source="https://github.com/hahwul/deadfinder"
+LABEL org.opencontainers.image.documentation="https://github.com/hahwul/deadfinder"
+LABEL org.opencontainers.image.licenses="MIT"
+
+LABEL "com.github.actions.name"="DeadFinder"
+LABEL "com.github.actions.description"="Find dead (broken) links in files, URLs, or sitemaps"
+LABEL "com.github.actions.icon"="link"
+LABEL "com.github.actions.color"="red"
+
+ENV LC_ALL=C.UTF-8
+
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /build/deadfinder /usr/local/bin/deadfinder
 CMD ["deadfinder"]


### PR DESCRIPTION
## Summary
hwaro의 publish-ghcr.yml 패턴을 참고해 Docker 파이프라인을 강화한다.

## 변경

### Dockerfile
- OCI 표준 라벨 7종 추가 (title/description/authors/source/documentation/licenses)
- GitHub Action 라벨 추가 (\`com.github.actions.*\`)
- \`LC_ALL=C.UTF-8\` 환경변수 세팅

### docker-ghcr.yml (퍼블리시)
- **build-by-digest + manifest-list 패턴**: 각 아키텍처를 독립 러너에서 병렬 빌드 → merge job이 manifest list로 합쳐서 단일 이미지 태그로 푸시
- \`docker/metadata-action\`으로 semver 태그 자동 생성:
  - release 이벤트 → \`2.0.0\`, \`2.0\`, \`latest\`
  - push main → \`main\`
  - workflow_dispatch → 입력 버전 + \`latest\`
- **Cosign keyless 서명**: Sigstore/Fulcio 기반, 장기 보관 키 없이 Supply chain 검증 가능

### docker-build.yml (PR CI)
- arm64 빌드를 QEMU 에뮬레이션에서 **네이티브 \`ubuntu-24.04-arm\` 러너**로 전환 → 약 10배 빠름 (#213 머지 후 관찰된 12분 → 1분대)
- GHA 캐시 스코프를 플랫폼별로 분리 (이전엔 공유돼서 서로 덮어씀)

## 참고
- hwaro \`.github/workflows/publish-ghcr.yml\` 구조 반영
- cosign 서명은 \`COSIGN_EXPERIMENTAL=true\` + OIDC keyless flow

## Test plan
- [ ] Docker Build CI (PR) — 두 아키텍처 모두 녹색, 특히 arm64 소요 시간 단축 확인
- [ ] \`workflow_dispatch\`로 docker-ghcr.yml 수동 실행 → \`ghcr.io/hahwul/deadfinder:<input>\` + \`:latest\` 푸시
- [ ] (v2.0.0 릴리스 후) cosign 서명 검증: \`cosign verify ghcr.io/hahwul/deadfinder:2.0.0 --certificate-identity=...\`