### PR TITLE
docs: add CHANGELOG.md with v2.0.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows [SemVer](https://semver.org/).
+
+## [Unreleased]
+
+## [2.0.0] — Crystal rewrite
+
+### Added
+- Crystal implementation (fiber-based concurrency via `spawn` + `Channel`) replaces the Ruby gem as the supported runtime.
+- Multi-platform release binaries auto-attached on every GitHub Release: linux x86_64/aarch64 (static/musl), macOS arm64/x86_64. Each tarball ships alongside a `.sha256` sidecar.
+- Cross-implementation compatibility harness (`spec/compat/`) — black-box golden files captured from v1 Ruby output, locking the CLI/output contract for Crystal.
+- GitHub Action migrated to a composite action that downloads the release binary and verifies its sha256 before running. The `version` input (defaulting to `latest`) lets callers pin a specific release. `worker_headers` is now a first-class input.
+- Docker image rebuilt on Crystal static binary (`alpine:3.21` runtime, `<15 MB`). OCI labels, semver tags (`2.0.0` / `2.0` / `latest`), and keyless cosign signatures on every published tag.
+
+### Changed
+- Repository layout: Crystal at the root. `src/`, `spec/`, `shard.yml`, `shard.lock` live at the top level; the old `crystal/` subdirectory is gone.
+- CLI flag behavior aligns with Ruby v1 exactly — the compat harness enforces this. No user-visible flag renames.
+- `--silent` default remains `false`; `-s` opts in. (An earlier Crystal port defaulted silent to `true`; that regression was fixed before the 2.0.0 cut.)
+- `--user_agent`, `--proxy_auth`, `--worker_headers` use underscores (as implemented). Prior dashed forms never worked reliably in the old Docker-based action; the new composite action passes the correct names.
+
+### Fixed
+- Resolved URLs preserve the base URL's non-default port for both `href="/path"` and `href="relative/path"` shapes (was dropping the port in the Crystal port).
+- Docker-based GitHub Action chain: previously relied on a Ruby-gem image and a brittle entrypoint.sh; replaced with a composite action that downloads the release binary directly.
+
+### Removed
+- Ruby gem publishing from `main`. The gem continues on the [`legacy/v1`](https://github.com/hahwul/deadfinder/tree/legacy/v1) branch for bug-fix and security releases only.
+- `lib/`, `bin/`, `Gemfile`, `Gemfile.lock`, `Rakefile`, `deadfinder.gemspec`, `gemset.nix`, `.rubocop.yml`, `ruby-version`, Ruby-based `flake.nix`, and the legacy Ruby spec suite.
+- `github-action/Dockerfile` + `entrypoint.sh` (replaced by composite action in `action.yml`).
+
+### Migration from v1
+
+| You had | Switch to |
+|---|---|
+| `gem install deadfinder` | `brew install deadfinder` or prebuilt binary from the release |
+| `bundle exec deadfinder …` | Same binary on `PATH`, no bundler |
+| Docker image (same name) | No change — the image now ships the Crystal binary |
+| `uses: hahwul/deadfinder@…` | No change — the action now uses the Crystal binary under the hood |
+| `require 'deadfinder'` | Library usage is gone from main. If you depend on it, pin to a v1 gem release or use the CLI. |
+
+If you need a bugfix in v1, open an issue/PR against the [`legacy/v1`](https://github.com/hahwul/deadfinder/tree/legacy/v1) branch.
+
+---
+
+History prior to 2.0.0 was not maintained in this file. See [GitHub Releases](https://github.com/hahwul/deadfinder/releases?q=prerelease%3Afalse) and the [`legacy/v1`](https://github.com/hahwul/deadfinder/tree/legacy/v1) branch for v1 release history.
+
+[Unreleased]: https://github.com/hahwul/deadfinder/compare/2.0.0...HEAD
+[2.0.0]: https://github.com/hahwul/deadfinder/releases/tag/2.0.0


### PR DESCRIPTION
## Summary
루트에 \`CHANGELOG.md\`를 추가하고 v2.0.0 (Crystal rewrite) 엔트리를 작성한다. Keep a Changelog 형식.

## 포함 섹션
- **Added**: Crystal 구현, 멀티 플랫폼 릴리스 바이너리, compat harness, composite action, Docker + cosign
- **Changed**: 저장소 구조, CLI 플래그 표면, silent 기본값, underscore flag 명칭
- **Fixed**: 포트 보존 버그, Docker 기반 action 체인
- **Removed**: Ruby gem publishing, lib/bin/Gemfile 등 Ruby 아티팩트, 구 action wrapper
- **Migration from v1**: 설치 경로별 대응표

## 참고
v1.x 이전 히스토리는 역소급하지 않는다 (GitHub Releases + legacy/v1 브랜치가 소스). v2.0.0 릴리스 노트에서 이 CHANGELOG 엔트리를 링크로 참조하면 됨.