### PR TITLE
ci: generate CycloneDX SBOM on release

### DIFF
--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -1,0 +1,38 @@
+---
+name: Generate and Upload SBOM
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Generate SBOM (CycloneDX, Crystal)
+        uses: hahwul/cyclonedx-cr@v1.0.2
+        with:
+          shard_file: ./shard.yml
+          lock_file: ./shard.lock
+          output_file: ./sbom.xml
+          output_format: xml
+          spec_version: 1.6
+
+      - name: Upload SBOM to Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./sbom.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SBOM as workflow artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom
+          path: ./sbom.xml


### PR DESCRIPTION
## Summary
릴리스 이벤트에서 Crystal shard 의존성 기반 **CycloneDX 1.6 SBOM**을 생성해 릴리스 자산으로 첨부한다.

## 구현
- 새 워크플로우: \`.github/workflows/release-sbom.yml\`
- \`hahwul/cyclonedx-cr@v1.0.2\` 액션 사용 (shard.yml + shard.lock 기반)
- \`release: published\` 트리거 → 자산 업로드
- \`workflow_dispatch\` 트리거 → artifact로 저장 (사전 검증용)

## 참고
- hwaro의 \`release-sbom.yml\` 패턴 차용
- Supply chain security 요구사항 (SLSA, 규제 환경) 대응

## Test plan
- [ ] \`workflow_dispatch\`로 수동 실행 → \`sbom\` artifact 다운로드해 유효한 CycloneDX XML인지 확인
- [ ] v2.0.0 릴리스 시 자동 첨부 확인