### PR TITLE
ci: add .deb / .rpm / .apk packaging workflows

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -1,0 +1,127 @@
+---
+name: Build and Release .apk Package
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build (e.g., 2.0.0)"
+        required: true
+        type: string
+      upload_to_release:
+        description: "Upload .apk to GitHub Release (requires existing tag)"
+        required: false
+        type: boolean
+        default: false
+  workflow_run:
+    workflows: ["Crystal Release Builds"]
+    types: [completed]
+
+permissions:
+  contents: write
+
+jobs:
+  build-apk:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            asset_arch: x86_64
+          - arch: aarch64
+            asset_arch: aarch64
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest
+    steps:
+      - name: Install build tools
+        run: apk add --no-cache alpine-sdk sudo github-cli git
+
+      - name: Trust workspace
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.event.workflow_run.head_branch }}
+
+      - name: Resolve version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RAW="${{ github.event.inputs.version }}"
+          else
+            RAW="${{ github.event.workflow_run.head_branch }}"
+          fi
+          VERSION="${RAW#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Download prebuilt binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "${{ env.VERSION }}" \
+            --pattern "deadfinder-linux-${{ matrix.asset_arch }}.tar.gz" \
+            --output deadfinder.tar.gz
+          tar xzf deadfinder.tar.gz
+          chmod +x deadfinder
+
+      - name: Setup abuild
+        run: |
+          adduser -D builder
+          addgroup builder abuild
+          echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+          sudo -u builder abuild-keygen -ain
+
+      - name: Create APKBUILD
+        run: |
+          mkdir -p /home/builder/deadfinder
+          cp deadfinder /home/builder/deadfinder/
+          cp LICENSE /home/builder/deadfinder/
+          cat > /home/builder/deadfinder/APKBUILD <<APKEOF
+          # Maintainer: HAHWUL <hahwul@gmail.com>
+          pkgname=deadfinder
+          pkgver=${{ env.VERSION }}
+          pkgrel=0
+          pkgdesc="Find dead (broken) links in web pages, URL lists, and sitemaps."
+          url="https://github.com/hahwul/deadfinder"
+          arch="${{ matrix.arch }}"
+          license="MIT"
+          source=""
+          options="!check !strip !tracedeps"
+
+          package() {
+          	install -Dm755 "\$srcdir/../deadfinder" "\$pkgdir/usr/bin/deadfinder"
+          	install -Dm644 "\$srcdir/../LICENSE" "\$pkgdir/usr/share/licenses/\$pkgname/LICENSE"
+          }
+          APKEOF
+          sed -i 's/^          //' /home/builder/deadfinder/APKBUILD
+          chown -R builder:builder /home/builder/deadfinder
+
+      - name: Build .apk
+        run: |
+          cd /home/builder/deadfinder
+          sudo -u builder -H CARCH=${{ matrix.arch }} abuild -F checksum
+          sudo -u builder -H CARCH=${{ matrix.arch }} abuild -Fr
+
+      - name: Collect artifacts
+        run: |
+          mkdir -p output
+          find /home/builder/packages -name "*.apk" ! -name "APKINDEX*" -exec cp {} output/ \;
+          ls -la output/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: deadfinder-${{ env.VERSION }}-${{ matrix.arch }}.apk
+          path: output/*.apk
+
+      - name: Upload .apk to Release
+        if: github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.upload_to_release)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for f in output/*.apk; do
+            gh release upload "${{ env.VERSION }}" "$f" --clobber
+          done

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -1,0 +1,92 @@
+---
+name: Build and Release .deb Package
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build (e.g., 2.0.0)"
+        required: true
+        type: string
+      upload_to_release:
+        description: "Upload .deb to GitHub Release (requires existing tag)"
+        required: false
+        type: boolean
+        default: false
+  workflow_run:
+    workflows: ["Crystal Release Builds"]
+    types: [completed]
+
+permissions:
+  contents: write
+
+jobs:
+  build-deb:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            asset_arch: x86_64
+          - arch: arm64
+            asset_arch: aarch64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.event.workflow_run.head_branch }}
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RAW="${{ github.event.inputs.version }}"
+          else
+            RAW="${{ github.event.workflow_run.head_branch }}"
+          fi
+          VERSION="${RAW#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Resolved: $VERSION"
+
+      - name: Download prebuilt binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "${{ env.VERSION }}" \
+            --pattern "deadfinder-linux-${{ matrix.asset_arch }}.tar.gz" \
+            --output deadfinder.tar.gz
+          tar xzf deadfinder.tar.gz
+          chmod +x deadfinder
+
+      - name: Build Debian package layout
+        run: |
+          PKGDIR="deadfinder_${{ env.VERSION }}_${{ matrix.arch }}"
+          mkdir -p "$PKGDIR/DEBIAN" "$PKGDIR/usr/bin" "$PKGDIR/usr/share/doc/deadfinder"
+          cp deadfinder "$PKGDIR/usr/bin/"
+          cp README.md "$PKGDIR/usr/share/doc/deadfinder/"
+          cp LICENSE "$PKGDIR/usr/share/doc/deadfinder/"
+          cat > "$PKGDIR/DEBIAN/control" <<EOF
+          Package: deadfinder
+          Version: ${{ env.VERSION }}
+          Architecture: ${{ matrix.arch }}
+          Maintainer: HAHWUL <hahwul@gmail.com>
+          Description: Find dead (broken) links in web pages, URL lists, and sitemaps.
+          EOF
+          dpkg-deb --build "$PKGDIR"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: deadfinder_${{ env.VERSION }}_${{ matrix.arch }}.deb
+          path: deadfinder_${{ env.VERSION }}_${{ matrix.arch }}.deb
+
+      - name: Upload .deb to Release
+        if: github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.upload_to_release)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ env.VERSION }}" \
+            "deadfinder_${{ env.VERSION }}_${{ matrix.arch }}.deb" --clobber

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -1,0 +1,103 @@
+---
+name: Build and Release .rpm Package
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build (e.g., 2.0.0)"
+        required: true
+        type: string
+      upload_to_release:
+        description: "Upload .rpm to GitHub Release (requires existing tag)"
+        required: false
+        type: boolean
+        default: false
+  workflow_run:
+    workflows: ["Crystal Release Builds"]
+    types: [completed]
+
+permissions:
+  contents: write
+
+jobs:
+  build-rpm:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            asset_arch: x86_64
+          - arch: aarch64
+            asset_arch: aarch64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.event.workflow_run.head_branch }}
+
+      - name: Resolve version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RAW="${{ github.event.inputs.version }}"
+          else
+            RAW="${{ github.event.workflow_run.head_branch }}"
+          fi
+          VERSION="${RAW#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Download prebuilt binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "${{ env.VERSION }}" \
+            --pattern "deadfinder-linux-${{ matrix.asset_arch }}.tar.gz" \
+            --output deadfinder.tar.gz
+          tar xzf deadfinder.tar.gz
+          chmod +x deadfinder
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: Install nfpm
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+
+      - name: Build .rpm
+        run: |
+          cat > nfpm.yaml <<EOF
+          name: deadfinder
+          arch: ${{ matrix.arch }}
+          version: ${{ env.VERSION }}
+          maintainer: HAHWUL <hahwul@gmail.com>
+          description: "Find dead (broken) links in web pages, URL lists, and sitemaps."
+          license: MIT
+          contents:
+            - src: deadfinder
+              dst: /usr/bin/deadfinder
+              file_info:
+                mode: 0755
+            - src: LICENSE
+              dst: /usr/share/licenses/deadfinder/LICENSE
+              file_info:
+                mode: 0644
+          EOF
+          nfpm package --packager rpm --target deadfinder-${{ env.VERSION }}.${{ matrix.arch }}.rpm
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: deadfinder-${{ env.VERSION }}.${{ matrix.arch }}.rpm
+          path: deadfinder-${{ env.VERSION }}.${{ matrix.arch }}.rpm
+
+      - name: Upload .rpm to Release
+        if: github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.upload_to_release)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ env.VERSION }}" \
+            "deadfinder-${{ env.VERSION }}.${{ matrix.arch }}.rpm" --clobber


### PR DESCRIPTION
## Summary
\`crystal-release.yml\`이 생성한 tar.gz 바이너리를 consume해 **Linux 패키지 포맷 3종**을 릴리스 자산으로 첨부한다.

| 포맷 | 도구 | 대상 배포판 | 아키텍처 |
|---|---|---|---|
| .deb | dpkg-deb | Debian, Ubuntu | amd64, arm64 |
| .rpm | nfpm (Go) | RHEL, Fedora, openSUSE | x86_64, aarch64 |
| .apk | abuild (Alpine container) | Alpine Linux | x86_64, aarch64 |

## 트리거
- \`workflow_run\`: \`Crystal Release Builds\` 완료 + release 이벤트 → 자동 실행
- \`workflow_dispatch\`: 수동 재빌드 (\`upload_to_release\` 체크박스로 업로드 여부 제어)

## 기대 자산 (v2.0.0 릴리스 예시)
\`\`\`
deadfinder_2.0.0_amd64.deb
deadfinder_2.0.0_arm64.deb
deadfinder-2.0.0.x86_64.rpm
deadfinder-2.0.0.aarch64.rpm
deadfinder-2.0.0-r0.x86_64.apk
deadfinder-2.0.0-r0.aarch64.apk
\`\`\`

## 참고
- hwaro의 \`release-deb.yml\`, \`release-rpm.yml\`, \`release-apk.yml\` 구조를 그대로 차용하고 deadfinder의 자산 네이밍(tar.gz)·태그 규약(v 접두사 없음)에 맞춰 적응시킴
- AUR/Snap은 사용자가 직접 진행 예정

## Test plan
- [ ] \`workflow_dispatch\`로 3개 워크플로우 각각 수동 실행 → artifact 생성 확인
- [ ] v2.0.0 릴리스 시 체인 트리거 동작 → 6개 자산 모두 첨부
- [ ] 각 패키지의 설치 테스트:
  - \`sudo dpkg -i deadfinder_2.0.0_amd64.deb && deadfinder version\`
  - \`sudo rpm -i deadfinder-2.0.0.x86_64.rpm && deadfinder version\`
  - \`apk add --allow-untrusted deadfinder-2.0.0-r0.x86_64.apk && deadfinder version\`