### PR TITLE
build: add Crystal-based Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@
 /deadfinder-*.tar.gz.sha256
 
 # Nix
-result
-result-*
+/result
+/result-*
 .direnv/
 
 # Zola docs site

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "DeadFinder — find dead (broken) links in web pages, URL lists, and sitemaps";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        deadfinder = pkgs.crystal.buildCrystalPackage rec {
+          pname = "deadfinder";
+          version = "2.0.0";
+
+          src = ./.;
+
+          # Generate with: crystal2nix > shards.nix
+          shardsFile = ./shards.nix;
+
+          crystalBinaries.deadfinder = {
+            src = "src/cli_main.cr";
+            options = [ "--release" "--no-debug" ];
+          };
+
+          nativeBuildInputs = with pkgs; [ crystal shards cmake pkg-config ];
+          buildInputs = [ ];
+
+          doCheck = false;
+
+          meta = with pkgs.lib; {
+            description = "Find dead (broken) links in web pages, URL lists, and sitemaps";
+            homepage = "https://github.com/hahwul/deadfinder";
+            license = licenses.mit;
+            maintainers = [ "hahwul" ];
+            mainProgram = "deadfinder";
+          };
+        };
+      in
+      {
+        packages.default = deadfinder;
+        packages.deadfinder = deadfinder;
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ deadfinder ];
+          nativeBuildInputs = with pkgs; [ crystal shards crystal2nix cmake pkg-config just ];
+          shellHook = ''
+            echo "deadfinder development environment (Nix)"
+            [ -d lib ] || shards install
+          '';
+        };
+      });
+}


### PR DESCRIPTION
## Summary
v2 restructure 때 삭제된 Ruby 기반 \`flake.nix\`를 **Crystal용으로 새로 작성**한다. hwaro의 flake 패턴을 그대로 차용.

## 구성
- \`pkgs.crystal.buildCrystalPackage\` 사용
- \`shardsFile = ./shards.nix\` (crystal2nix로 생성)
- \`nativeBuildInputs\`: \`crystal\`, \`shards\`, \`cmake\`, \`pkg-config\` (lexbor 빌드용)
- \`devShells.default\`: 개발 환경 (crystal2nix, just 포함)
- Entry hook에서 \`shards install\` 자동 실행

## 한계: \`shards.nix\`는 이번 PR에 포함 안 됨
생성에 \`crystal2nix\` 실행이 필요한데, 이 도구는 Nix 환경에서만 돌고 내 로컬에 없음. 머지 후 다음 커맨드로 한 번만 생성해주시면 그 뒤 \`nix run github:hahwul/deadfinder\`가 동작함:

\`\`\`bash
nix develop
crystal2nix > shards.nix
git add shards.nix
git commit -m "build: add generated shards.nix"
\`\`\`

또는 별도 follow-up PR로 shards.nix만 따로 올려도 됨.

## Test plan (머지 + shards.nix 커밋 후)
- [ ] \`nix build\` 성공, \`./result/bin/deadfinder version\` 출력 \`2.0.0\`
- [ ] \`nix develop\` 진입 → \`shards install\` 없이 이미 lib/가 세팅됨
- [ ] \`nix run github:hahwul/deadfinder -- url https://example.com\` 동작