### PR TITLE
ci: add AUR publishing workflow

### DIFF
--- a/.github/workflows/release-aur.yml
+++ b/.github/workflows/release-aur.yml
@@ -1,0 +1,49 @@
+---
+name: Publish AUR Package
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g., 2.0.0)"
+        required: true
+        type: string
+  workflow_run:
+    workflows: ["Crystal Release Builds"]
+    types: [completed]
+
+jobs:
+  publish-aur:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.event.workflow_run.head_branch }}
+
+      - name: Resolve version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RAW="${{ github.event.inputs.version }}"
+          else
+            RAW="${{ github.event.workflow_run.head_branch }}"
+          fi
+          VERSION="${RAW#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Update PKGBUILD
+        run: |
+          sed -i "s/^pkgver=.*/pkgver=${{ env.VERSION }}/" aur/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" aur/PKGBUILD
+          cat aur/PKGBUILD
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.2
+        with:
+          pkgname: deadfinder
+          pkgbuild: aur/PKGBUILD
+          commit_username: hahwul
+          commit_email: hahwul@gmail.com
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,0 +1,20 @@
+# Maintainer: HAHWUL <hahwul@gmail.com>
+pkgname=deadfinder
+pkgver=2.0.0
+pkgrel=1
+pkgdesc="Find dead (broken) links in web pages, URL lists, and sitemaps"
+arch=('x86_64' 'aarch64')
+url="https://github.com/hahwul/deadfinder"
+license=('MIT')
+
+source_x86_64=("${pkgname}-${pkgver}-x86_64.tar.gz::${url}/releases/download/${pkgver}/deadfinder-linux-x86_64.tar.gz")
+source_aarch64=("${pkgname}-${pkgver}-aarch64.tar.gz::${url}/releases/download/${pkgver}/deadfinder-linux-aarch64.tar.gz")
+source=("LICENSE-${pkgver}::https://raw.githubusercontent.com/hahwul/deadfinder/${pkgver}/LICENSE")
+sha256sums=('SKIP')
+sha256sums_x86_64=('SKIP')
+sha256sums_aarch64=('SKIP')
+
+package() {
+  install -Dm755 "${srcdir}/deadfinder" "${pkgdir}/usr/bin/${pkgname}"
+  install -Dm644 "${srcdir}/LICENSE-${pkgver}" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}


### PR DESCRIPTION
## Summary
Arch Linux 사용자 대상으로 AUR에 \`deadfinder\` 패키지를 자동 업로드한다.

## 구성

### \`aur/PKGBUILD\`
- \`pkgname=deadfinder\`
- 멀티 아키텍처: \`x86_64\`, \`aarch64\` 둘 다 지원
- 릴리스 tar.gz에서 바이너리 추출 (\`deadfinder-linux-{arch}.tar.gz\`)
- \`LICENSE\`는 raw.githubusercontent.com에서 fetch (checkout 없이 makepkg 동작 가능)
- \`sha256sums=('SKIP')\` (hwaro와 동일 패턴; 추후 릴리스 .sha256 sidecar 반영 가능)

### \`.github/workflows/release-aur.yml\`
- **트리거**: release 이벤트 후 \`Crystal Release Builds\` 성공 시 \`workflow_run\` 자동 / \`workflow_dispatch\`로 수동
- \`sed\`로 PKGBUILD의 \`pkgver\` / \`pkgrel\` 갱신 후 AUR git에 푸시
- \`KSXGitHub/github-actions-deploy-aur@v4.1.2\` 사용
- \`secrets.AUR_SSH_PRIVATE_KEY\` 소비 (hwaro와 동일 env var, 이미 세팅됨)

## 설치 경험 (머지 후 v2.0.0 릴리스 기준)
\`\`\`bash
yay -S deadfinder
# 또는
paru -S deadfinder
\`\`\`

## Test plan
- [ ] \`workflow_dispatch\`로 수동 실행 → AUR 저장소 업데이트 확인
- [ ] v2.0.0 릴리스 체인에서 자동 트리거 → \`pkgver=2.0.0\` PKGBUILD 푸시 확인
- [ ] Arch 환경에서 \`makepkg\` 빌드 성공 + \`deadfinder version\` 출력 \`2.0.0\`

## 주의
처음 실행 전 AUR 측에 \`deadfinder\` 패키지 이름이 이미 선점되어 있지 않은지 확인 필요. (첫 업로드가 AUR 저장소를 생성함)