### PR TITLE
ci: add Snap Store publishing workflow

### DIFF
--- a/.github/workflows/publish-snapcraft.yml
+++ b/.github/workflows/publish-snapcraft.yml
@@ -1,0 +1,44 @@
+---
+name: Snapcraft Publish
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: Log level
+        required: true
+        default: warning
+      tags:
+        description: Test scenario tags
+
+jobs:
+  snapcraft-releaser:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - amd64
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build snap
+        id: build
+        uses: canonical/action-build@v1
+
+      - name: Publish snap to the stable channel
+        if: github.event_name == 'release'
+        uses: snapcore/action-publish@master
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: stable
+
+      - name: Upload snap as workflow artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
+        with:
+          name: deadfinder-snap-${{ matrix.platform }}
+          path: ${{ steps.build.outputs.snap }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,51 @@
+name: deadfinder
+base: core24
+version: 2.0.0
+summary: Find dead (broken) links in web pages, URL lists, and sitemaps.
+description: |
+  DeadFinder is a fast CLI tool for detecting broken links on a page, a
+  list of URLs, or an entire sitemap. Written in Crystal for native
+  speed and fiber-based concurrency. Supports JSON/YAML/TOML/CSV output
+  and coverage reporting.
+
+grade: stable
+confinement: strict
+license: MIT
+
+apps:
+  deadfinder:
+    command: deadfinder
+    plugs:
+      - home
+      - removable-media
+      - network
+      - network-bind
+
+parts:
+  deadfinder:
+    source: ./
+    plugin: nil
+    override-build: |
+      curl -fsSL https://crystal-lang.org/install.sh | bash
+      shards install --production
+      shards build --release --no-debug --production
+      cp ./bin/deadfinder $CRAFT_PART_INSTALL/
+    build-packages:
+      - git
+      - curl
+      - cmake
+      - make
+      - g++
+      - pkg-config
+      - libssl-dev
+      - libxml2-dev
+      - libz-dev
+      - libyaml-dev
+      - libpcre2-dev
+      - libevent-dev
+      - libgmp-dev
+    stage-packages:
+      - libxml2
+      - zlib1g
+      - libyaml-0-2
+      - ca-certificates


### PR DESCRIPTION
## Summary
Snap Store에 \`deadfinder\` snap을 자동 퍼블리시한다. hwaro의 Snap 설정을 그대로 참고하고 deadfinder 빌드 환경(cmake + lexbor)에 맞춰 조정.

## 구성

### \`snap/snapcraft.yaml\`
- \`name=deadfinder\`, \`base=core24\`, \`confinement=strict\`
- **Plugs**: \`network\`, \`network-bind\` (HTTP 스캔), \`home\`, \`removable-media\` (URL 파일 읽기)
- **Build packages**: hwaro에 더해 \`cmake\`, \`make\`, \`g++\` 추가 (lexbor 컴파일용)
- **Stage packages**: \`libxml2\`, \`zlib1g\`, \`libyaml-0-2\`, \`ca-certificates\`
- 빌드 방식: \`shards build --release --no-debug --production\` → \`./bin/deadfinder\`

### \`.github/workflows/publish-snapcraft.yml\`
- **트리거**: release 이벤트 (자동 퍼블리시), \`workflow_dispatch\` (수동 검증용)
- \`canonical/action-build@v1\`으로 snap 빌드
- \`snapcore/action-publish@master\`로 stable 채널 퍼블리시
- \`secrets.SNAP_STORE_LOGIN\` 소비 (hwaro와 동일 시크릿명, 사용자 env에 이미 있음)
- \`workflow_dispatch\`는 artifact로 저장 → 태깅 전 검증 가능

## 설치 경험 (머지 + v2.0.0 릴리스 후)
\`\`\`bash
sudo snap install deadfinder
deadfinder version
\`\`\`

## 아키텍처
amd64만 우선 (hwaro와 동일). arm64는 나중에 수요 생기면 추가.

## 버전 스크립트 follow-up
\`scripts/version_check.cr\` / \`version_update.cr\` (#226)에 snap + aur 파일 추적을 추가해야 다음 릴리스 때 \`just version-update 2.1.0\`이 \`snap/snapcraft.yaml\`·\`aur/PKGBUILD\`도 bump함. #226, #228, #229 모두 머지된 후 작은 follow-up PR로 처리 예정.

## Test plan
- [ ] \`workflow_dispatch\`로 수동 실행 → snap 아티팩트 다운로드 + \`snap install --devmode\` 로컬 검증
- [ ] v2.0.0 릴리스 체인 트리거 → Snap Store stable 채널 푸시 확인
- [ ] 실사용: \`sudo snap install deadfinder && deadfinder url https://example.com\`