### PR TITLE
fix(ci): upgrade cosign to 2.4.1 and simplify signing

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -95,9 +95,9 @@ jobs:
           merge-multiple: true
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.0.0
+        uses: sigstore/cosign-installer@v3.7.0
         with:
-          cosign-release: v2.1.1
+          cosign-release: v2.4.1
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
@@ -142,13 +142,11 @@ jobs:
       - name: Sign the published image with cosign (keyless)
         if: github.event_name != 'pull_request'
         env:
-          COSIGN_EXPERIMENTAL: "true"
           TAGS: ${{ steps.meta.outputs.tags }}
-          DIGEST: ${{ steps.meta.outputs.version }}
         run: |
-          # Re-resolve the digest for each published tag and sign it.
+          # Cosign resolves each tag to its manifest digest and records
+          # the signature in the registry (Sigstore keyless / OIDC flow).
           for tag in $TAGS; do
-            digest=$(docker buildx imagetools inspect "$tag" --raw | sha256sum | awk '{print $1}')
-            echo "Signing ${tag}@sha256:${digest}"
-            cosign sign --yes "${tag}@sha256:${digest}"
+            echo "Signing ${tag}"
+            cosign sign --yes "${tag}"
           done


### PR DESCRIPTION
## Summary
머지된 #222의 GHCR 서명 단계가 main에서 실패 중:

\`\`\`
Error: signing ...: getting key from Fulcio: getting CTFE public keys:
updating local metadata and targets: error updating to TUF remote mirror: invalid key
\`\`\`

**원인**: cosign 2.1.1의 TUF 메타데이터 이슈 (알려진 문제, 신버전에서 수정됨).

## 수정
- \`sigstore/cosign-installer\` \`v4.0.0\` → \`v3.7.0\` + \`cosign-release: v2.4.1\`
- 수동 digest 재조회 루프 제거 — cosign 2.x는 \`cosign sign --yes <tag>\` 만으로 tag를 manifest digest로 해석해 서명
- \`COSIGN_EXPERIMENTAL\` 환경변수 제거 (2.x에서는 불필요)

## 확인 사항
- 머지 후 push-to-main 트리거에서 GHCR Publish 녹색인지
- 이후 v2.0.0 릴리스 시 태그별 서명도 정상 기록되는지