### PR TITLE
fix(action): friendly error on missing binary + drop @latest from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,12 @@ deadfinder sitemap https://www.hahwul.com/sitemap.xml
 ```
 
 ### GitHub Action
+Pin a specific release tag. `@latest` is **not** a valid Actions ref.
+
 ```yml
 steps:
 - name: Run DeadFinder
-  uses: hahwul/deadfinder@latest
+  uses: hahwul/deadfinder@2.0.0   # or any released tag: see Releases page
   id: broken-link
   with:
     command: sitemap           # url / file / sitemap / pipe

--- a/action.yml
+++ b/action.yml
@@ -103,8 +103,20 @@ runs:
           base_url="https://github.com/hahwul/deadfinder/releases/download/${version}"
         fi
         echo "Downloading ${base_url}/${asset}"
-        curl -fsSL "${base_url}/${asset}" -o /tmp/deadfinder.tar.gz
-        curl -fsSL "${base_url}/${asset}.sha256" -o /tmp/deadfinder.tar.gz.sha256
+        if ! curl -fsSL "${base_url}/${asset}" -o /tmp/deadfinder.tar.gz; then
+          echo "::error title=DeadFinder binary not found::Failed to download ${base_url}/${asset}"
+          echo "::error::Common causes:"
+          echo "::error::  1. Using 'uses: hahwul/deadfinder@main' before the v2.0.0 release is published."
+          echo "::error::     → Pin a released version instead: uses: hahwul/deadfinder@2.0.0"
+          echo "::error::  2. Requested version (input: version=${version}) is not yet released."
+          echo "::error::     → See https://github.com/hahwul/deadfinder/releases for available tags."
+          echo "::error::  3. Using a v1.x workflow with a v2 ref — v1 users should pin hahwul/deadfinder@1.10.0."
+          exit 1
+        fi
+        if ! curl -fsSL "${base_url}/${asset}.sha256" -o /tmp/deadfinder.tar.gz.sha256; then
+          echo "::error::Downloaded ${asset} but its .sha256 sidecar is missing at ${base_url}/${asset}.sha256"
+          exit 1
+        fi
         cd /tmp
         # macOS runners ship `shasum`, Linux ships `sha256sum`.
         if command -v sha256sum >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
두 가지 작은 수정:

### 1. action.yml 방어 코드
v2 composite action이 \`main\`에 머지된 시점부터 **v2.0.0 태깅 전까지**의 창에서는 \`uses: hahwul/deadfinder@main\` 사용자가 \`releases/latest/download/deadfinder-linux-x86_64.tar.gz\`에서 404를 받는다. 현재는 curl의 무의미한 exit 22만 나온다. 이 PR은 다운로드 실패를 catch해서 GitHub 스타일 \`::error::\` 주석으로 **세 가지 흔한 원인과 대처법**을 안내한다:

\`\`\`
::error title=DeadFinder binary not found::Failed to download ...
::error::Common causes:
::error::  1. Using 'uses: hahwul/deadfinder@main' before the v2.0.0 release is published.
::error::     → Pin a released version instead: uses: hahwul/deadfinder@2.0.0
::error::  2. Requested version (input: version=latest) is not yet released.
::error::     → See https://github.com/hahwul/deadfinder/releases for available tags.
::error::  3. Using a v1.x workflow with a v2 ref — v1 users should pin hahwul/deadfinder@1.10.0.
\`\`\`

### 2. README 문서 버그 수정
\`uses: hahwul/deadfinder@latest\`는 **GitHub Actions에 자동 리졸버가 없어** 예전부터 깨져 있던 안내였다. \`@latest\`는 \`latest\`라는 이름의 브랜치/태그가 있을 때만 동작한다. 예시를 \`@2.0.0\` 고정 + 릴리스 페이지 링크로 교체.

## 영향도

| 사용자 | 변화 |
|---|---|
| \`@main\` + v2.0.0 미태깅 (현재 창) | 에러 메시지가 명확해짐. 동작 자체는 여전히 실패 (태깅 후 자동 정상화) |
| \`@1.10.0\` 등 v1 태그 | 영향 없음 (각 태그의 action.yml 그대로) |
| \`@2.0.0\` 이후 | 정상 동작 |

## 관련
- 바로 다음 단계는 **v2.0.0 태깅** (#220)로 이 창 자체를 닫음