### PR TITLE
fix(security): verify TLS certs by default; fail loudly on proxy CONNECT errors

### DIFF
--- a/spec/deadfinder/http_client_spec.cr
+++ b/spec/deadfinder/http_client_spec.cr
@@ -43,6 +43,22 @@ describe Deadfinder::HttpClient do
       client = Deadfinder::HttpClient.create(uri, options)
       client.should be_a(HTTP::Client)
     end
+
+    it "creates an HTTPS client when insecure flag is enabled" do
+      uri = URI.parse("https://example.com")
+      options = default_test_options
+      options.insecure = true
+      client = Deadfinder::HttpClient.create(uri, options)
+      client.should be_a(HTTP::Client)
+    end
+
+    it "creates an HTTPS client with verification enabled by default" do
+      uri = URI.parse("https://example.com")
+      options = default_test_options
+      options.insecure.should be_false
+      client = Deadfinder::HttpClient.create(uri, options)
+      client.should be_a(HTTP::Client)
+    end
   end
 
   describe ".proxy_configured?" do

--- a/src/deadfinder/cli.cr
+++ b/src/deadfinder/cli.cr
@@ -31,6 +31,7 @@ module Deadfinder
         parser.on("--user_agent=UA", "User-Agent string") { |v| options.user_agent = v }
         parser.on("-p PROXY", "--proxy=PROXY", "Proxy server") { |v| options.proxy = v }
         parser.on("--proxy_auth=CREDS", "Proxy authentication (user:pass)") { |v| options.proxy_auth = v }
+        parser.on("-k", "--insecure", "Skip TLS certificate verification (not recommended)") { options.insecure = true }
         parser.on("-m PATTERN", "--match=PATTERN", "Match URL pattern") { |v| options.match = v }
         parser.on("-i PATTERN", "--ignore=PATTERN", "Ignore URL pattern") { |v| options.ignore = v }
         parser.on("-s", "--silent", "Silent mode") { options.silent = true }

--- a/src/deadfinder/http_client.cr
+++ b/src/deadfinder/http_client.cr
@@ -53,14 +53,13 @@ module Deadfinder
             response_line = socket.gets
             unless response_line && response_line.includes?("200")
               socket.close
-              # Fallback to direct connection
-              return create_direct(host, port, use_ssl, options)
+              raise "Proxy CONNECT to #{host}:#{target_port} via #{proxy_host}:#{proxy_port} failed: #{response_line.try(&.strip) || "no response"}"
             end
             # Consume remaining headers
             while (line = socket.gets) && !line.strip.empty?
             end
 
-            tls_socket = OpenSSL::SSL::Socket::Client.new(socket, context: ssl_context, hostname: host)
+            tls_socket = OpenSSL::SSL::Socket::Client.new(socket, context: ssl_context(options), hostname: host)
             client = HTTP::Client.new(io: tls_socket, host: host, port: target_port)
             client.read_timeout = options.timeout.seconds
             return client
@@ -92,7 +91,7 @@ module Deadfinder
     end
 
     private def self.create_direct(host : String, port : Int32?, use_ssl : Bool, options : Options) : HTTP::Client
-      client = HTTP::Client.new(host, port: port, tls: use_ssl ? ssl_context : nil)
+      client = HTTP::Client.new(host, port: port, tls: use_ssl ? ssl_context(options) : nil)
       client.read_timeout = options.timeout.seconds
       client.connect_timeout = options.timeout.seconds
       client
@@ -116,9 +115,9 @@ module Deadfinder
       end
     end
 
-    private def self.ssl_context : OpenSSL::SSL::Context::Client
+    private def self.ssl_context(options : Options) : OpenSSL::SSL::Context::Client
       ctx = OpenSSL::SSL::Context::Client.new
-      ctx.verify_mode = OpenSSL::SSL::VerifyMode::NONE
+      ctx.verify_mode = options.insecure ? OpenSSL::SSL::VerifyMode::NONE : OpenSSL::SSL::VerifyMode::PEER
       ctx
     end
   end

--- a/src/deadfinder/types.cr
+++ b/src/deadfinder/types.cr
@@ -12,6 +12,7 @@ module Deadfinder
     property include30x : Bool = false
     property proxy : String = ""
     property proxy_auth : String = ""
+    property insecure : Bool = false
     property match : String = ""
     property ignore : String = ""
     property user_agent : String = "Mozilla/5.0 (compatible; DeadFinder/#{VERSION};)"


### PR DESCRIPTION
## Summary

- **TLS verification on by default.** `http_client.cr` was unconditionally setting `VerifyMode::NONE`, making every HTTPS request vulnerable to MITM. Switched default to `VerifyMode::PEER`.
- **New flag:** \`-k\` / \`--insecure\` opts back into the old behavior for environments with self-signed certs or internal CAs.
- **Proxy CONNECT failure is no longer silent.** When an HTTPS proxy CONNECT returned anything but 200, the code silently fell back to a direct connection — bypassing the user-requested proxy without warning. Now raises with the proxy response line so the failure is visible.

## Test plan

- [x] \`crystal spec\` — 123 examples, 0 failures
- [x] New specs covering \`options.insecure = true\` and default-secure path
- [x] \`deadfinder --help\` shows the new \`-k, --insecure\` flag

## Notes

This is a behavior change for users currently relying on the implicit \"skip verify\" default. The new \`--insecure\` flag restores the old behavior for them. The proxy fallback change is intentional — silent fallback masks a real misconfiguration.