### PR TITLE
refactor: split worker() into claim/check/record steps; dedupe match?/ignore?

### DIFF
--- a/src/deadfinder/runner.cr
+++ b/src/deadfinder/runner.cr
@@ -120,79 +120,103 @@ module Deadfinder
                cache_set : Hash(String, Bool),
                mutex : Mutex)
       loop do
-        j = jobs.receive? || break
+        url = jobs.receive? || break
 
-        already_cached = mutex.synchronize { cache_set[j]? }
-        if already_cached
-          results.send(j)
+        unless claim_url(url, cache_set, mutex)
+          results.send(url)
           next
         end
 
-        mutex.synchronize { cache_set[j] = true }
-
-        # Track total URLs tested for coverage
-        if options.coverage
-          mutex.synchronize do
-            coverage_data[target] ||= TargetCoverage.new
-            coverage_data[target].total += 1
-          end
-        end
+        record_total(target, options, coverage_data, mutex)
 
         begin
-          uri = URI.parse(j)
-          client = HttpClient.create(uri, options)
-
-          request_headers = HTTP::Headers.new
-          request_headers["User-Agent"] = options.user_agent
-          options.worker_headers.each do |header|
-            parts = header.split(":", 2)
-            if parts.size == 2
-              request_headers[parts[0].strip] = parts[1].strip
-            end
-          end
-
-          worker_path = if HttpClient.proxy_configured?(options) && uri.scheme == "http"
-                          HttpClient.absolute_uri(uri)
-                        else
-                          request_path(uri)
-                        end
-          response = client.get(worker_path, headers: request_headers)
-          client.close
-          status_code = response.status_code
-
-          if status_code >= 400 || (status_code >= 300 && options.include30x)
-            Deadfinder::Logger.found "[#{status_code}] #{j}"
-            mutex.synchronize do
-              output[target] ||= [] of String
-              output[target] << j
-              if options.coverage
-                coverage_data[target].dead += 1
-                coverage_data[target].status_counts[status_code.to_s] =
-                  (coverage_data[target].status_counts[status_code.to_s]? || 0) + 1
-              end
-            end
-          else
-            Deadfinder::Logger.verbose_ok "[#{status_code}] #{j}" if options.verbose
-            if options.coverage
-              mutex.synchronize do
-                coverage_data[target].status_counts[status_code.to_s] =
-                  (coverage_data[target].status_counts[status_code.to_s]? || 0) + 1
-              end
-            end
-          end
+          status_code = check_url(url, options)
+          record_status(target, url, status_code, options, output, coverage_data, mutex)
         rescue ex
-          Deadfinder::Logger.verbose "[#{ex}] #{j}" if options.verbose
-          if options.coverage
-            mutex.synchronize do
-              coverage_data[target] ||= TargetCoverage.new
-              coverage_data[target].dead += 1
-              coverage_data[target].status_counts["error"] =
-                (coverage_data[target].status_counts["error"]? || 0) + 1
-            end
-          end
+          Deadfinder::Logger.verbose "[#{ex}] #{url}" if options.verbose
+          record_error(target, options, coverage_data, mutex)
         end
 
-        results.send(j)
+        results.send(url)
+      end
+    end
+
+    # Returns true if this worker now owns `url` (first-time check),
+    # false if another worker already claimed it.
+    private def claim_url(url : String, cache_set : Hash(String, Bool), mutex : Mutex) : Bool
+      mutex.synchronize do
+        return false if cache_set[url]?
+        cache_set[url] = true
+        true
+      end
+    end
+
+    private def check_url(url : String, options : Options) : Int32
+      uri = URI.parse(url)
+      client = HttpClient.create(uri, options)
+      headers = HTTP::Headers.new
+      headers["User-Agent"] = options.user_agent
+      options.worker_headers.each do |header|
+        parts = header.split(":", 2)
+        if parts.size == 2
+          headers[parts[0].strip] = parts[1].strip
+        end
+      end
+
+      path = if HttpClient.proxy_configured?(options) && uri.scheme == "http"
+               HttpClient.absolute_uri(uri)
+             else
+               request_path(uri)
+             end
+      response = client.get(path, headers: headers)
+      client.close
+      response.status_code
+    end
+
+    private def record_total(target : String, options : Options,
+                             coverage_data : Hash(String, TargetCoverage),
+                             mutex : Mutex) : Nil
+      return unless options.coverage
+      mutex.synchronize do
+        coverage_data[target] ||= TargetCoverage.new
+        coverage_data[target].total += 1
+      end
+    end
+
+    private def record_status(target : String, url : String, status_code : Int32,
+                              options : Options,
+                              output : Hash(String, Array(String)),
+                              coverage_data : Hash(String, TargetCoverage),
+                              mutex : Mutex) : Nil
+      dead = status_code >= 400 || (status_code >= 300 && options.include30x)
+      if dead
+        Deadfinder::Logger.found "[#{status_code}] #{url}"
+      else
+        Deadfinder::Logger.verbose_ok "[#{status_code}] #{url}" if options.verbose
+      end
+
+      mutex.synchronize do
+        if dead
+          output[target] ||= [] of String
+          output[target] << url
+        end
+        if options.coverage
+          coverage_data[target].dead += 1 if dead
+          coverage_data[target].status_counts[status_code.to_s] =
+            (coverage_data[target].status_counts[status_code.to_s]? || 0) + 1
+        end
+      end
+    end
+
+    private def record_error(target : String, options : Options,
+                             coverage_data : Hash(String, TargetCoverage),
+                             mutex : Mutex) : Nil
+      return unless options.coverage
+      mutex.synchronize do
+        coverage_data[target] ||= TargetCoverage.new
+        coverage_data[target].dead += 1
+        coverage_data[target].status_counts["error"] =
+          (coverage_data[target].status_counts["error"]? || 0) + 1
       end
     end
 

--- a/src/deadfinder/runner.cr
+++ b/src/deadfinder/runner.cr
@@ -195,6 +195,10 @@ module Deadfinder
         Deadfinder::Logger.verbose_ok "[#{status_code}] #{url}" if options.verbose
       end
 
+      # Skip the mutex entirely on the common "alive + no coverage" path
+      # so we don't serialize every live link on the cache-set mutex.
+      return unless dead || options.coverage
+
       mutex.synchronize do
         if dead
           output[target] ||= [] of String

--- a/src/deadfinder/url_pattern_matcher.cr
+++ b/src/deadfinder/url_pattern_matcher.cr
@@ -3,20 +3,14 @@ module Deadfinder
     TIMEOUT_DURATION = 1.second
 
     def self.match?(url : String, pattern : String) : Bool
-      regex = Regex.new(pattern)
-      result_ch = Channel(Bool).new(1)
-      spawn do
-        result_ch.send(regex.matches?(url))
-      end
-      select
-      when result = result_ch.receive
-        result
-      when timeout(TIMEOUT_DURATION)
-        false
-      end
+      matches_with_timeout?(url, pattern)
     end
 
     def self.ignore?(url : String, pattern : String) : Bool
+      matches_with_timeout?(url, pattern)
+    end
+
+    private def self.matches_with_timeout?(url : String, pattern : String) : Bool
       regex = Regex.new(pattern)
       result_ch = Channel(Bool).new(1)
       spawn do


### PR DESCRIPTION
## Summary

Pure refactor — no behavior change, same 121 specs pass.

**\`Runner#worker\`** was an 82-line block mixing cache claim, header assembly, HTTP execution, status-class branching, output mutation, and three different coverage-update paths. Split into small, named helpers so each step is obvious in isolation:

- \`claim_url\` — atomic first-time claim under the mutex
- \`check_url\` — build request, dispatch, return status code
- \`record_total\` / \`record_status\` / \`record_error\` — coverage + output updates, each holding the mutex exactly where it needs to

\`worker\` itself is now just the orchestration loop. As a side effect, the coverage logic for dead-vs-alive is unified (the previous code had two near-identical mutex blocks that incremented \`status_counts\` with slightly different structures).

**\`UrlPatternMatcher.match?\`** and **\`.ignore?\`** were byte-identical. Collapsed to a shared private \`matches_with_timeout?\` helper; both public entry points are preserved so call sites still read naturally.

## Test plan

- [x] \`crystal spec\` — 121 examples, 0 failures
- [x] The webmock-backed runner integration suite (\`spec/deadfinder/runner_spec.cr\`, 559 lines) exercises the new helpers end-to-end — 404/200/redirect/error paths, coverage on/off, include30x, custom headers

## Notes

Kept both \`match?\` and \`ignore?\` public even though they're now aliases — they're semantically distinct at the call sites (one filters in, the other filters out) and renaming them would ripple through the runner.