### PR TITLE
feat: add SARIF 2.1.0 output format (-f sarif)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Options:
   -c, --concurrency=N              Number of concurrent workers (default: 50)
   -t, --timeout=N                  Timeout in seconds (default: 10)
   -o, --output=FILE                File to write results
-  -f, --output_format=FORMAT       Output format: json, yaml, toml, csv (default: json)
+  -f, --output_format=FORMAT       Output format: json, yaml, toml, csv, sarif (default: json)
   -H, --headers=HEADER             Custom HTTP headers for initial request
       --worker_headers=HEADER      Custom HTTP headers for worker requests
       --user_agent=UA              User-Agent string

--- a/docs/content/docs/getting-started/quickstart.md
+++ b/docs/content/docs/getting-started/quickstart.md
@@ -39,7 +39,7 @@ cat output.json
 }
 ```
 
-YAML, TOML, CSV are available via `-f <format>`. See [Output formats](/docs/usage/output-formats/).
+YAML, TOML, CSV, and SARIF are available via `-f <format>`. See [Output formats](/docs/usage/output-formats/).
 
 ## Scan a sitemap
 

--- a/docs/content/docs/reference/cli-flags.md
+++ b/docs/content/docs/reference/cli-flags.md
@@ -28,7 +28,7 @@ Commands:
 | `-c` | `--concurrency=N` | `50` | Number of concurrent workers. |
 | `-t` | `--timeout=N` | `10` | Per-request timeout (seconds). |
 | `-o` | `--output=FILE` | `""` | Write structured results to FILE. |
-| `-f` | `--output_format=FORMAT` | `json` | `json` / `yaml` / `toml` / `csv`. |
+| `-f` | `--output_format=FORMAT` | `json` | `json` / `yaml` / `toml` / `csv` / `sarif`. |
 | `-H` | `--headers=HEADER` | `[]` | Header for the **initial** page fetch. Repeat for multiple. Format: `"Name: Value"`. |
 | | `--worker_headers=HEADER` | `[]` | Header for every **link-check** request. Repeat for multiple. |
 | | `--user_agent=UA` | `Mozilla/5.0 (compatible; DeadFinder/<VERSION>;)` | Override User-Agent. |

--- a/docs/content/docs/usage/_index.md
+++ b/docs/content/docs/usage/_index.md
@@ -8,5 +8,5 @@ sort_by = "weight"
 DeadFinder is a single CLI with four scan subcommands and a handful of global flags.
 
 - [Subcommands](/docs/usage/subcommands/) — `url`, `file`, `pipe`, `sitemap`, plus `completion` and `version`.
-- [Output formats](/docs/usage/output-formats/) — JSON / YAML / TOML / CSV, coverage, PNG visualization.
+- [Output formats](/docs/usage/output-formats/) — JSON / YAML / TOML / CSV / SARIF, coverage, PNG visualization.
 - [Filtering](/docs/usage/filtering/) — `--match` / `--ignore` regex, `--include30x`, `--limit`.

--- a/docs/content/docs/usage/output-formats.md
+++ b/docs/content/docs/usage/output-formats.md
@@ -1,6 +1,6 @@
 +++
 title = "Output Formats"
-description = "JSON, YAML, TOML, CSV, coverage reports, and PNG visualization."
+description = "JSON, YAML, TOML, CSV, SARIF, coverage reports, and PNG visualization."
 weight = 2
 +++
 
@@ -12,6 +12,7 @@ DeadFinder writes results only when `-o <FILE>` is set (stdout stays human-reada
 | `-f yaml` / `-f yml` | YAML |
 | `-f toml` | TOML |
 | `-f csv` | CSV with `target,url` columns |
+| `-f sarif` | SARIF 2.1.0 JSON (one `DEAD_LINK` result per broken URL) |
 
 ## Basic shape
 
@@ -65,6 +66,16 @@ deadfinder sitemap https://www.example.com/sitemap.xml --coverage -o out.json
   }
 }
 ```
+
+## SARIF
+
+`-f sarif` produces a [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) document you can upload to GitHub code scanning (`github/codeql-action/upload-sarif`) or feed into any SARIF-aware tooling:
+
+```bash
+deadfinder sitemap https://www.example.com/sitemap.xml -f sarif -o deadfinder.sarif
+```
+
+Each dead link becomes a `result` under the `DEAD_LINK` rule. The broken URL is the primary location; the page it was discovered on is attached as a related location.
 
 ## PNG visualization
 

--- a/shard.lock
+++ b/shard.lock
@@ -4,6 +4,10 @@ shards:
     git: https://github.com/kostya/lexbor.git
     version: 3.4.2
 
+  sarif:
+    git: https://github.com/hahwul/sarif.cr.git
+    version: 0.2.0
+
   stumpy_core:
     git: https://github.com/stumpycr/stumpy_core.git
     version: 1.9.1

--- a/shard.yml
+++ b/shard.yml
@@ -14,6 +14,9 @@ dependencies:
   stumpy_png:
     github: stumpycr/stumpy_png
     version: "~> 5.0"
+  sarif:
+    github: hahwul/sarif.cr
+    version: "~> 0.2.0"
 
 development_dependencies:
   webmock:

--- a/spec/deadfinder_spec.cr
+++ b/spec/deadfinder_spec.cr
@@ -296,6 +296,66 @@ describe Deadfinder do
       end
     end
 
+    context "when output_format is sarif" do
+      it "writes a valid SARIF 2.1.0 document with a DEAD_LINK result per broken URL" do
+        tempfile = File.tempfile("deadfinder_output", ".sarif")
+        begin
+          options = default_test_options
+          options.output = tempfile.path
+          options.output_format = "sarif"
+
+          Deadfinder.output["http://example.com"] = ["http://example.com/page1", "http://example.com/page2"]
+          Deadfinder.gen_output(options)
+
+          content = File.read(tempfile.path)
+          parsed = JSON.parse(content)
+
+          parsed["version"].as_s.should eq "2.1.0"
+          parsed["$schema"].as_s.should contain "sarif-schema-2.1.0"
+
+          run = parsed["runs"].as_a.first
+          run["tool"]["driver"]["name"].as_s.should eq "deadfinder"
+          run["tool"]["driver"]["version"].as_s.should eq Deadfinder::VERSION
+
+          rules = run["tool"]["driver"]["rules"].as_a
+          rules.size.should eq 1
+          rules[0]["id"].as_s.should eq "DEAD_LINK"
+
+          results = run["results"].as_a
+          results.size.should eq 2
+          result_uris = results.map { |r| r["locations"].as_a.first["physicalLocation"]["artifactLocation"]["uri"].as_s }
+          result_uris.should contain "http://example.com/page1"
+          result_uris.should contain "http://example.com/page2"
+          results.each do |r|
+            r["ruleId"].as_s.should eq "DEAD_LINK"
+            r["level"].as_s.should eq "warning"
+            r["relatedLocations"].as_a.first["physicalLocation"]["artifactLocation"]["uri"].as_s.should eq "http://example.com"
+          end
+        ensure
+          tempfile.delete
+        end
+      end
+
+      it "produces an empty results array when there are no dead links" do
+        tempfile = File.tempfile("deadfinder_output", ".sarif")
+        begin
+          options = default_test_options
+          options.output = tempfile.path
+          options.output_format = "sarif"
+
+          Deadfinder.gen_output(options)
+
+          content = File.read(tempfile.path)
+          parsed = JSON.parse(content)
+          parsed["version"].as_s.should eq "2.1.0"
+          run = parsed["runs"].as_a.first
+          run["tool"]["driver"]["name"].as_s.should eq "deadfinder"
+        ensure
+          tempfile.delete
+        end
+      end
+    end
+
     context "when output is empty" do
       it "does nothing if output file is not specified" do
         options = default_test_options

--- a/src/deadfinder.cr
+++ b/src/deadfinder.cr
@@ -3,6 +3,7 @@ require "json"
 require "yaml"
 require "csv"
 require "xml"
+require "sarif"
 require "./deadfinder/version"
 require "./deadfinder/types"
 require "./deadfinder/utils"
@@ -218,6 +219,8 @@ module Deadfinder
                   generate_csv(output_data, coverage_info)
                 when "toml"
                   generate_toml(output_data, coverage_info)
+                when "sarif"
+                  generate_sarif(output_data, coverage_info)
                 else
                   generate_json(output_data, coverage_info)
                 end
@@ -424,6 +427,39 @@ module Deadfinder
     end
 
     lines.join("\n") + "\n"
+  end
+
+  # Produce a SARIF 2.1.0 report where each dead link is a `Result` with
+  # rule id "DEAD_LINK". The scanned target is attached as a related
+  # location so downstream tools (GitHub code scanning, editors) can link
+  # back to the page on which the broken URL was found.
+  private def self.generate_sarif(output_data : Hash(String, Array(String)), coverage_info : CoverageResult?) : String
+    log = Sarif::Builder.build do |b|
+      b.run("deadfinder", Deadfinder::VERSION) do |r|
+        r.information_uri("https://github.com/hahwul/deadfinder")
+        r.rule(
+          "DEAD_LINK",
+          name: "DeadLink",
+          short_description: "Broken or unreachable link",
+          full_description: "A link on the scanned page returned an HTTP error status or failed to resolve.",
+          help_uri: "https://github.com/hahwul/deadfinder",
+          level: Sarif::Level::Warning,
+        )
+
+        output_data.each do |target, urls|
+          urls.each do |url|
+            r.result do |rb|
+              rb.message("Dead link detected: #{url} (found on #{target})")
+              rb.rule_id("DEAD_LINK")
+              rb.level(Sarif::Level::Warning)
+              rb.location(uri: url)
+              rb.related_location(uri: target, message_text: "Referenced from this page")
+            end
+          end
+        end
+      end
+    end
+    log.to_pretty_json
   end
 
   private def self.toml_key(key : String) : String

--- a/src/deadfinder/cli.cr
+++ b/src/deadfinder/cli.cr
@@ -25,7 +25,7 @@ module Deadfinder
         parser.on("-c CONCURRENCY", "--concurrency=CONCURRENCY", "Number of concurrency (default: 50)") { |v| options.concurrency = v.to_i }
         parser.on("-t TIMEOUT", "--timeout=TIMEOUT", "Timeout in seconds (default: 10)") { |v| options.timeout = v.to_i }
         parser.on("-o OUTPUT", "--output=OUTPUT", "File to write result") { |v| options.output = v }
-        parser.on("-f FORMAT", "--output_format=FORMAT", "Output format: json, yaml, toml, csv (default: json)") { |v| options.output_format = v }
+        parser.on("-f FORMAT", "--output_format=FORMAT", "Output format: json, yaml, toml, csv, sarif (default: json)") { |v| options.output_format = v }
         parser.on("-H HEADER", "--headers=HEADER", "Custom HTTP headers for initial request") { |v| options.headers << v }
         parser.on("--worker_headers=HEADER", "Custom HTTP headers for worker requests") { |v| options.worker_headers << v }
         parser.on("--user_agent=UA", "User-Agent string") { |v| options.user_agent = v }


### PR DESCRIPTION
## Summary
- Adds `-f sarif` so `deadfinder` can emit a [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) JSON report — ready to upload to GitHub code scanning via `github/codeql-action/upload-sarif`, or feed into any SARIF-aware tooling.
- Each broken URL becomes a `DEAD_LINK` result: primary location is the broken URL, related location is the page it was discovered on.
- Built on top of [hahwul/sarif.cr](https://github.com/hahwul/sarif.cr) (`~> 0.2.0`) — schema/version fields, enums, and JSON serialization are handled by the shard.

## Example
```bash
deadfinder sitemap https://www.example.com/sitemap.xml -f sarif -o deadfinder.sarif
```

```json
{
  "version": "2.1.0",
  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
  "runs": [
    {
      "tool": {
        "driver": {
          "name": "deadfinder",
          "version": "2.0.2",
          "informationUri": "https://github.com/hahwul/deadfinder",
          "rules": [{ "id": "DEAD_LINK", "name": "DeadLink", ... }]
        }
      },
      "results": [
        {
          "ruleId": "DEAD_LINK",
          "level": "warning",
          "message": { "text": "Dead link detected: https://example.com/missing (found on https://example.com)" },
          "locations": [ { "physicalLocation": { "artifactLocation": { "uri": "https://example.com/missing" } } } ],
          "relatedLocations": [ { "physicalLocation": { "artifactLocation": { "uri": "https://example.com" } } } ]
        }
      ]
    }
  ]
}
```

## Changes
- `shard.yml` / `shard.lock`: add `sarif` (`hahwul/sarif.cr ~> 0.2.0`).
- `src/deadfinder.cr`: `generate_sarif` helper + `"sarif"` case in `gen_output`.
- `src/deadfinder/cli.cr`: list `sarif` in the `-f` help string.
- Docs: README, `cli-flags.md`, `output-formats.md`, `quickstart.md`, `usage/_index.md` updated.
- Specs: two new cases in `spec/deadfinder_spec.cr` (populated results + empty-results shape).

## Test plan
- [x] `crystal spec` — 134 examples, 0 failures.
- [x] `crystal build src/cli_main.cr` — clean build.
- [x] Manual smoke test: `deadfinder url <page> -f sarif -o out.sarif` produces valid SARIF 2.1.0 JSON (`version`, `$schema`, `runs[0].tool.driver.name == "deadfinder"`).