### PR TITLE
chore: pin contributors-list action and avoid commit noise

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -9,13 +9,26 @@
             description: manual run
             required: false
             default: ''
+    permissions:
+      contents: write
+      pull-requests: write
     jobs:
       contributors:
         runs-on: ubuntu-latest
         steps:
-          - uses: wow-actions/contributors-list@v1
+          - uses: actions/checkout@v4
+          - uses: wow-actions/contributors-list@v1.2.1
             with:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               round: false
               includeBots: false
               svgPath: docs/static/images/CONTRIBUTORS.svg
+              noCommit: true
+          - uses: peter-evans/create-pull-request@v8.1.1
+            with:
+              token: ${{ secrets.GITHUB_TOKEN }}
+              commit-message: "chore: update contributors"
+              title: "chore: update contributors"
+              body: Automated update of `docs/static/images/CONTRIBUTORS.svg`.
+              branch: chore/update-contributors
+              delete-branch: true


### PR DESCRIPTION
## Summary
- Pin `wow-actions/contributors-list` to `v1.2.1` instead of the floating `v1` tag.
- Enable `noCommit: true` so the workflow no longer pushes `chore: update contributors [skip ci]` directly to `main`.
- Route SVG updates through `peter-evans/create-pull-request@v8.1.1` so changes land as a reviewable PR.

## Test plan
- [ ] Ensure **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** is enabled.
- [ ] Trigger the workflow via `workflow_dispatch` and confirm a `chore/update-contributors` PR is opened (or no-op if no diff).