### PR TITLE
fix(release): bundle Homebrew dylibs in macOS release tarballs

### DIFF
--- a/.github/workflows/crystal-release.yml
+++ b/.github/workflows/crystal-release.yml
@@ -75,18 +75,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install Crystal and cmake
-        run: brew install crystal cmake
+      - name: Install Crystal, cmake, and OpenSSL
+        run: brew install crystal cmake openssl@3 pkg-config
 
       - name: Build release binary
         run: |
           shards install
+          OPENSSL_PREFIX="$(brew --prefix openssl@3)"
+          export PKG_CONFIG_PATH="${OPENSSL_PREFIX}/lib/pkgconfig"
           crystal build src/cli_main.cr -o deadfinder --release --no-debug
 
       - name: Package
         run: |
-          chmod +x deadfinder
-          tar czf deadfinder-macos-${{ matrix.arch }}.tar.gz deadfinder
+          chmod +x scripts/package-macos.sh
+          scripts/package-macos.sh deadfinder "deadfinder-macos-${{ matrix.arch }}.tar.gz" deadfinder
           shasum -a 256 deadfinder-macos-${{ matrix.arch }}.tar.gz > deadfinder-macos-${{ matrix.arch }}.tar.gz.sha256
 
       - name: Upload to release

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Bundle Homebrew-linked dylibs next to a Crystal macOS binary so the
+# release tarball runs without a local OpenSSL (or other brew) install.
+#
+# Usage: scripts/package-macos.sh <binary-path> <output-tarball> [staged-name]
+#
+# Archive layout:
+#   <staged-name>
+#   lib/*.dylib
+set -euo pipefail
+
+BINARY="${1:?Usage: $0 <binary-path> <output-tarball> [staged-name]}"
+OUTPUT="${2:?Usage: $0 <binary-path> <output-tarball> [staged-name]}"
+NAME="${3:-$(basename "$BINARY")}"
+
+if [[ ! -f "$BINARY" ]]; then
+  echo "error: binary not found: $BINARY" >&2
+  exit 1
+fi
+
+if ! command -v otool >/dev/null 2>&1 || ! command -v install_name_tool >/dev/null 2>&1; then
+  echo "error: otool and install_name_tool are required (macOS only)" >&2
+  exit 1
+fi
+
+STAGING="$(mktemp -d)"
+trap 'rm -rf "$STAGING"' EXIT
+
+mkdir -p "$STAGING/lib"
+cp "$BINARY" "$STAGING/$NAME"
+chmod +x "$STAGING/$NAME"
+
+BREW_PREFIX_RE='^(/opt/homebrew|/usr/local)/'
+
+homebrew_deps() {
+  local target="$1"
+  otool -L "$target" | awk 'NR>1 {print $1}' | grep -E "$BREW_PREFIX_RE" || true
+}
+
+DEPS_FILE="$STAGING/deps.txt"
+: > "$DEPS_FILE"
+
+while true; do
+  added=0
+  for target in "$STAGING/$NAME" "$STAGING"/lib/*.dylib; do
+    [[ -e "$target" ]] || continue
+    while IFS= read -r dep; do
+      [[ -z "$dep" ]] && continue
+      base="$(basename "$dep")"
+      if ! grep -Fxq "$dep" "$DEPS_FILE"; then
+        echo "$dep" >> "$DEPS_FILE"
+      fi
+      if [[ ! -f "$STAGING/lib/$base" ]]; then
+        cp "$dep" "$STAGING/lib/$base"
+        added=1
+      fi
+    done < <(homebrew_deps "$target")
+  done
+  [[ "$added" -eq 0 ]] && break
+done
+
+rewrite_paths() {
+  local target="$1"
+  while IFS= read -r dep; do
+    [[ -z "$dep" ]] && continue
+    install_name_tool -change "$dep" "@executable_path/lib/$(basename "$dep")" "$target"
+  done < "$DEPS_FILE"
+}
+
+rewrite_paths "$STAGING/$NAME"
+for lib in "$STAGING"/lib/*.dylib; do
+  [[ -e "$lib" ]] || continue
+  install_name_tool -id "@executable_path/lib/$(basename "$lib")" "$lib"
+  rewrite_paths "$lib"
+done
+
+if otool -L "$STAGING/$NAME" | awk 'NR>1 {print $1}' | grep -Eq "$BREW_PREFIX_RE"; then
+  echo "error: Homebrew paths remain after bundling:" >&2
+  otool -L "$STAGING/$NAME" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUTPUT")"
+tar -czf "$OUTPUT" -C "$STAGING" "$NAME" lib
+
+echo "Created $OUTPUT"
+if "$STAGING/$NAME" --version >/dev/null 2>&1; then
+  "$STAGING/$NAME" --version
+fi


### PR DESCRIPTION
## Summary

Bundle Homebrew-linked dylibs in macOS release tarballs so direct-download binaries run without a local OpenSSL install.

Previous macOS tarballs linked multiple Homebrew dylibs (openssl@3, libyaml, pcre2, bdw-gc).

## Changes

- Add `scripts/package-macos.sh`
- Update release workflow to build against `openssl@3`, package binary + `lib/` as `.tar.gz`

## Breaking change

macOS release assets change from a bare executable to a `.tar.gz` archive. Extract and keep `lib/` next to the binary.