### PR TITLE
fix(input): harden pipe/file URL list handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Usage: deadfinder <command> [options]
 
 Commands:
   pipe                        Scan the URLs from STDIN
-  file <FILE>                 Scan the URLs from File
+  file <FILE>                 Scan the URLs from File (`-` for STDIN)
   url <URL>                   Scan the Single URL
   sitemap <SITEMAP-URL>       Scan the URLs from sitemap
   completion <SHELL>          Generate completion script (bash/zsh/fish)
@@ -142,11 +142,34 @@ cat urls.txt | deadfinder pipe
 # Scan the URLs from a file
 deadfinder file urls.txt
 
+# `-` and other non-regular files (process substitution, /dev/stdin, FIFOs) work too
+deadfinder file -  < urls.txt
+deadfinder file <(subfinder -d example.com -silent | httpx -silent)
+
 # Scan a single URL
 deadfinder url https://www.hahwul.com
 
 # Scan the URLs from a sitemap
 deadfinder sitemap https://www.hahwul.com/sitemap.xml
+```
+
+### URL list format (`pipe` / `file`)
+
+One URL per line. The list is normalized before scanning:
+
+- surrounding whitespace is trimmed, and a leading UTF-8 BOM is dropped
+- blank lines and `#` comments are skipped
+- duplicate URLs are scanned once
+- lines that are not absolute `http://` / `https://` URLs are reported and skipped
+- `--limit N` counts only real targets, and stops reading the input once it is reached
+
+```
+# production
+https://www.hahwul.com
+https://www.hahwul.com/cullinan/
+
+# staging
+https://staging.hahwul.com
 ```
 
 ## JSON Handling

--- a/spec/deadfinder_spec.cr
+++ b/spec/deadfinder_spec.cr
@@ -153,6 +153,134 @@ describe Deadfinder do
         urlfile.delete
       end
     end
+
+    it "skips blank lines, whitespace padding and # comments" do
+      target = "http://mock-blank.test"
+      html = %(<html><body><a href="http://mock-blank.test/dead">X</a></body></html>)
+
+      WebMock.stub(:get, target).to_return(body: html)
+      WebMock.stub(:get, "http://mock-blank.test/dead").to_return(status: 404)
+
+      urlfile = File.tempfile("deadfinder_blank", ".txt")
+      begin
+        File.write(urlfile.path, "\n   \n# a comment\n  #{target}  \n\n")
+
+        options = default_test_options
+        Deadfinder.run_file(urlfile.path, options)
+
+        # Padding is trimmed, so the report is keyed by the clean URL and the
+        # blank/comment lines never became (failing) targets of their own.
+        Deadfinder.output.keys.should eq [target]
+        Deadfinder.output[target].should contain "http://mock-blank.test/dead"
+      ensure
+        urlfile.delete
+      end
+    end
+
+    it "strips a leading UTF-8 BOM from the first line" do
+      target = "http://mock-bom.test"
+      html = %(<html><body><a href="http://mock-bom.test/dead">X</a></body></html>)
+
+      WebMock.stub(:get, target).to_return(body: html)
+      WebMock.stub(:get, "http://mock-bom.test/dead").to_return(status: 404)
+
+      urlfile = File.tempfile("deadfinder_bom", ".txt")
+      begin
+        File.write(urlfile.path, "#{Deadfinder::UTF8_BOM}#{target}\n")
+
+        options = default_test_options
+        Deadfinder.run_file(urlfile.path, options)
+
+        Deadfinder.output.keys.should eq [target]
+      ensure
+        urlfile.delete
+      end
+    end
+
+    it "counts only real targets against limit" do
+      html1 = %(<html><body><a href="http://lim1.test/page">P</a></body></html>)
+      html2 = %(<html><body><a href="http://lim2.test/page">P</a></body></html>)
+
+      WebMock.stub(:get, "http://lim1.test").to_return(body: html1)
+      WebMock.stub(:get, "http://lim1.test/page").to_return(status: 404)
+      WebMock.stub(:get, "http://lim2.test").to_return(body: html2)
+      WebMock.stub(:get, "http://lim2.test/page").to_return(status: 404)
+
+      urlfile = File.tempfile("deadfinder_limit_blank", ".txt")
+      begin
+        # Blank lines between the two targets used to consume the limit, so
+        # `--limit 2` scanned only the first URL.
+        File.write(urlfile.path, "http://lim1.test\n\n\nhttp://lim2.test\n")
+
+        options = default_test_options
+        options.limit = 2
+        Deadfinder.run_file(urlfile.path, options)
+
+        Deadfinder.output.keys.sort.should eq ["http://lim1.test", "http://lim2.test"]
+      ensure
+        urlfile.delete
+      end
+    end
+
+    it "skips targets that are not absolute http(s) URLs" do
+      urlfile = File.tempfile("deadfinder_invalid", ".txt")
+      begin
+        # A bare domain has no host once parsed, `file://` parses to an empty
+        # host, and a non-http scheme would otherwise be fetched as plain HTTP.
+        File.write(urlfile.path, "example.com\nfile:///etc/hosts\nftp://example.com/a\n")
+
+        options = default_test_options
+        Deadfinder.run_file(urlfile.path, options)
+
+        Deadfinder.output.should be_empty
+      ensure
+        urlfile.delete
+      end
+    end
+  end
+
+  describe ".read_targets" do
+    it "normalizes, dedupes and preserves first-seen order" do
+      io = IO::Memory.new(<<-LIST)
+        #{Deadfinder::UTF8_BOM}http://a.test
+
+          http://b.test\t
+        # http://commented.test
+        http://a.test
+        LIST
+
+      Deadfinder.read_targets(io, 0).should eq ["http://a.test", "http://b.test"]
+    end
+
+    it "handles CRLF line endings" do
+      io = IO::Memory.new("http://a.test\r\nhttp://b.test\r\n")
+      Deadfinder.read_targets(io, 0).should eq ["http://a.test", "http://b.test"]
+    end
+
+    it "rejects targets that cannot be fetched over http(s)" do
+      Deadfinder::Logger.set_silent
+      io = IO::Memory.new("example.com\nfile:///etc/hosts\nftp://x.test/a\n://broken\n")
+      Deadfinder.read_targets(io, 0).should be_empty
+    end
+
+    it "stops reading as soon as the limit is reached" do
+      # A still-open stream: without an early break the read would block here
+      # instead of returning the single target the limit asked for.
+      reader, writer = IO.pipe
+      begin
+        writer.puts "http://a.test"
+        writer.puts "http://b.test"
+        Deadfinder.read_targets(reader, 1).should eq ["http://a.test"]
+      ensure
+        writer.close
+        reader.close
+      end
+    end
+
+    it "counts only valid targets against the limit" do
+      io = IO::Memory.new("\n# c\nhttp://a.test\n\nhttp://b.test\n")
+      Deadfinder.read_targets(io, 2).should eq ["http://a.test", "http://b.test"]
+    end
   end
 
   describe "#run_sitemap" do

--- a/src/deadfinder.cr
+++ b/src/deadfinder.cr
@@ -17,6 +17,14 @@ require "./deadfinder/completion"
 module Deadfinder
   MAX_SITEMAP_DEPTH = 5
 
+  # `deadfinder file -` reads the list from STDIN, matching the convention of
+  # other CLI tools.
+  STDIN_FILENAME = "-"
+
+  # How many individually invalid input lines are reported before switching to
+  # a single summary line.
+  MAX_INVALID_TARGET_REPORTS = 10
+
   @@output = {} of String => Array(String)
   @@coverage_data = {} of String => TargetCoverage
   # Global URL -> HTTP status code cache. A URL is fetched at most once across
@@ -52,13 +60,7 @@ module Deadfinder
   end
 
   def self.run_pipe(options : Options)
-    run_with_input(options) do
-      lines = [] of String
-      while line = STDIN.gets
-        lines << line.chomp
-      end
-      lines
-    end
+    run_with_input(options) { read_targets(STDIN, options.limit) }
   end
 
   def self.run_file(filename : String, options : Options)
@@ -67,12 +69,68 @@ module Deadfinder
       # (permissions) or vanish between that check and this read (TOCTOU).
       # Report cleanly and scan nothing rather than crash.
       begin
-        File.read_lines(filename).map(&.chomp)
+        if filename == STDIN_FILENAME
+          read_targets(STDIN, options.limit)
+        else
+          File.open(filename) { |file| read_targets(file, options.limit) }
+        end
       rescue ex : IO::Error
         Deadfinder::Logger.error "Failed to read input file #{filename}: #{ex.message}"
         [] of String
       end
     end
+  end
+
+  # Reads scan targets from `io`, one per line, applying the input rules shared
+  # by the `pipe` and `file` commands:
+  #
+  #   * a leading UTF-8 BOM is dropped, so a list exported from Windows/Excel
+  #     doesn't lose its first URL
+  #   * surrounding whitespace is trimmed, so a padded line doesn't become a
+  #     distinct target (and a distinct key) in the report
+  #   * blank lines and `#` comments are skipped instead of being fetched —
+  #     neither can be a valid target, and both previously logged an error
+  #   * duplicates are dropped, keeping first-seen order
+  #   * lines that aren't absolute http(s) URLs are reported and skipped rather
+  #     than handed to the fetcher to fail on
+  #   * reading stops once `limit` targets are collected, so `--limit` no longer
+  #     drains a huge list (or a live stream) first — and, because only real
+  #     targets are counted, blank/comment lines can't eat into the limit
+  def self.read_targets(io : IO, limit : Int32) : Array(String)
+    targets = [] of String
+    seen = Set(String).new
+    invalid = 0
+    first_line = true
+
+    io.each_line(chomp: true) do |raw|
+      line = raw
+      if first_line
+        line = line.lchop(UTF8_BOM)
+        first_line = false
+      end
+      line = line.strip
+      next if line.empty? || line.starts_with?('#')
+
+      unless valid_target?(line)
+        invalid += 1
+        # Cap the per-line reports: a list of bare domains would otherwise
+        # bury everything else under one error per line.
+        if invalid <= MAX_INVALID_TARGET_REPORTS
+          Deadfinder::Logger.error "Skipping invalid target (expected an absolute http:// or https:// URL): #{line}"
+        end
+        next
+      end
+
+      next unless seen.add?(line)
+      targets << line
+      break if limit > 0 && targets.size >= limit
+    end
+
+    if invalid > MAX_INVALID_TARGET_REPORTS
+      Deadfinder::Logger.error "Skipped #{invalid} invalid targets in total"
+    end
+
+    targets
   end
 
   def self.run_url(url : String, options : Options)
@@ -169,13 +227,15 @@ module Deadfinder
   private def self.run_with_input(options : Options, &block : -> Array(String))
     Deadfinder::Logger.apply_options(options)
     Deadfinder::Logger.info "Reading input"
-    app = Runner.new
-    # Dedupe input targets: scanning the same page twice is wasted work and
-    # would double-count it in coverage totals.
-    targets = (yield).uniq
-    targets = targets.first(options.limit) if options.limit > 0
-    targets.each do |target|
-      run_with_target(target, options, app)
+    # `read_targets` has already trimmed, deduped and limited the list.
+    targets = yield
+    if targets.empty?
+      Deadfinder::Logger.info "No URLs to scan"
+    else
+      app = Runner.new
+      targets.each do |target|
+        run_with_target(target, options, app)
+      end
     end
     gen_output(options)
   end

--- a/src/deadfinder/cli.cr
+++ b/src/deadfinder/cli.cr
@@ -7,13 +7,14 @@ module Deadfinder
 
       subcommand : String? = nil
       positional_arg : String? = nil
+      extra_args = [] of String
 
       global_parser = OptionParser.new do |parser|
         parser.banner = "Usage: deadfinder <command> [options]"
         parser.separator ""
         parser.separator "Commands:"
         parser.separator "  pipe                        Scan the URLs from STDIN"
-        parser.separator "  file <FILE>                 Scan the URLs from File"
+        parser.separator "  file <FILE>                 Scan the URLs from File (`-` for STDIN)"
         parser.separator "  url <URL>                   Scan the Single URL"
         parser.separator "  sitemap <SITEMAP-URL>       Scan the URLs from sitemap"
         parser.separator "  completion <SHELL>           Generate completion script (bash/zsh/fish)"
@@ -49,6 +50,7 @@ module Deadfinder
           if remaining.size > 0
             subcommand = remaining[0]
             positional_arg = remaining[1]? if remaining.size > 1
+            extra_args = remaining[2..] if remaining.size > 2
           end
         end
       end
@@ -57,6 +59,19 @@ module Deadfinder
         global_parser.parse(args)
       rescue ex : OptionParser::Exception | ArgumentError
         STDERR.puts "Error: #{ex.message}"
+        exit 1
+      end
+
+      # Reject arguments the chosen subcommand cannot use instead of silently
+      # dropping them: `deadfinder file a.txt b.txt` used to scan only a.txt,
+      # and `deadfinder pipe urls.txt` used to ignore the file entirely and then
+      # block on an empty STDIN.
+      leftover = extra_args.dup
+      if (arg = positional_arg) && subcommand && ["pipe", "version"].includes?(subcommand)
+        leftover.unshift(arg)
+      end
+      unless leftover.empty?
+        STDERR.puts "Error: unexpected argument#{leftover.size > 1 ? "s" : ""} for `#{subcommand}`: #{leftover.join(" ")}"
         exit 1
       end
 
@@ -95,14 +110,25 @@ module Deadfinder
       when "file"
         if positional_arg
           filename = positional_arg.not_nil!
-          unless File.file?(filename)
-            STDERR.puts "Error: file not found: #{filename}"
-            exit 1
+          # `File.file?` is true only for regular files, which rejected every
+          # legitimate non-regular source: shell process substitution
+          # (`deadfinder file <(...)` -> /dev/fd/N), /dev/stdin, and named
+          # pipes all reported a bogus "file not found". Check existence
+          # instead, and name a directory for what it is.
+          if filename != Deadfinder::STDIN_FILENAME
+            if Dir.exists?(filename)
+              STDERR.puts "Error: #{filename} is a directory, not a file"
+              exit 1
+            end
+            unless File.exists?(filename)
+              STDERR.puts "Error: file not found: #{filename}"
+              exit 1
+            end
           end
           Deadfinder.run_file(filename, options)
         else
           STDERR.puts "Error: file command requires a filename argument"
-          STDERR.puts "Usage: deadfinder file <FILE> [options]"
+          STDERR.puts "Usage: deadfinder file <FILE> [options]  (use `-` to read from STDIN)"
           exit 1
         end
       when "url"

--- a/src/deadfinder/http_client.cr
+++ b/src/deadfinder/http_client.cr
@@ -10,21 +10,29 @@ module Deadfinder
     @@proxy_cache_mutex = Mutex.new
 
     def self.create(uri : URI, options : Options) : HTTP::Client
-      host = uri.host
+      # `presence` (not just `nil?`): `file:///etc/hosts` parses to an *empty*
+      # host, which passed a nil-check and then tried to connect to ":80".
+      host = uri.host.presence
       if host.nil?
         raise ArgumentError.new("URI is missing a host")
       end
+      scheme = uri.scheme
+      # Anything other than http/https cannot be fetched here; without this
+      # guard `ftp://host/x` was silently requested as plain HTTP on port 80.
+      unless scheme == "http" || scheme == "https"
+        raise ArgumentError.new("Unsupported URL scheme: #{scheme || "(none)"} (only http and https are supported)")
+      end
       port = uri.port
-      use_ssl = uri.scheme == "https"
+      use_ssl = scheme == "https"
 
       proxy_str = options.proxy
       if !proxy_str.empty?
         proxy_uri = resolve_proxy(proxy_str)
 
         if proxy_uri && proxy_uri.host
-          scheme = proxy_uri.scheme
-          if scheme && scheme != "http" && scheme != "https"
-            raise ArgumentError.new("Unsupported proxy scheme: #{scheme} (only http and https proxies are supported)")
+          proxy_scheme = proxy_uri.scheme
+          if proxy_scheme && proxy_scheme != "http" && proxy_scheme != "https"
+            raise ArgumentError.new("Unsupported proxy scheme: #{proxy_scheme} (only http and https proxies are supported)")
           end
 
           proxy_host = proxy_uri.host.not_nil!

--- a/src/deadfinder/utils.cr
+++ b/src/deadfinder/utils.cr
@@ -1,8 +1,28 @@
 module Deadfinder
   IGNORED_SCHEMES = ["mailto:", "tel:", "sms:", "data:", "file:", "javascript:", "#"]
 
+  # Byte-order mark that Windows/Excel-exported URL lists carry on their first
+  # line. It is not whitespace, so `String#strip` leaves it attached to the URL
+  # and quietly corrupts the very first target.
+  UTF8_BOM = "\uFEFF"
+
   def self.ignore_scheme?(url : String) : Bool
     IGNORED_SCHEMES.any? { |scheme| url.starts_with?(scheme) }
+  end
+
+  # True when `target` can actually be scanned: an absolute URL with an
+  # http/https scheme and a non-empty host. Everything else only produces a
+  # confusing failure downstream — a bare domain and a stray shell token both
+  # raise "URI is missing a host", `file:///etc/hosts` parses to an empty host
+  # and tries to connect to `:80`, and `ftp://host/x` would be fetched as plain
+  # HTTP — so callers report such lines and skip them instead.
+  def self.valid_target?(target : String) : Bool
+    uri = URI.parse(target)
+    scheme = uri.scheme
+    return false unless scheme == "http" || scheme == "https"
+    !uri.host.presence.nil?
+  rescue
+    false
   end
 
   def self.generate_url(text : String, base_url : String) : String?


### PR DESCRIPTION
## Summary

`pipe` and `file` each parsed their input inline and handed every raw line straight to the fetcher. This unifies both on a shared `Deadfinder.read_targets` and fixes 8 defects that were reproducible against the current binary.

## Fixed

| # | Defect | Before |
|---|---|---|
| 1 | Blank / whitespace-only lines became scan targets | 2 lines of error noise per blank line |
| 2 | `--limit` was consumed by blank lines | `--limit 2` over `a`, ``, ``, `b` scanned only `a` |
| 3 | Surrounding whitespace never trimmed | `  http://a  ` became a separate report key |
| 4 | UTF-8 BOM broke the first URL | Windows/Excel-exported lists always lost line 1 (`String#strip` does not remove U+FEFF) |
| 5 | `file` rejected every non-regular file | `file <(...)`, `/dev/stdin`, FIFOs → bogus "file not found"; a directory said the same |
| 6 | Extra positional args silently dropped | `file a.txt b.txt` scanned only a.txt; `pipe urls.txt` ignored the file and blocked on empty STDIN |
| 7 | `file:///...` connected to `:80` | Empty host passed the `nil?` check in `HttpClient` |
| 8 | `ftp://host/x` fetched as plain HTTP | No scheme validation before building the client |

## Also

- Reading stops as soon as `--limit` is satisfied — a 100k-line file with `--limit 1` now returns immediately, and live streams aren't drained first.
- `#` comment lines are supported, so URL lists can carry section headers.
- Invalid lines say *why* they were skipped, and collapse to a single summary past 10 — a mistakenly-piped bare-domain list no longer floods the screen.
- `No URLs to scan` is reported when the input yields nothing (previously silent).
- `deadfinder file -` reads from STDIN, matching the usual CLI convention.

## Test plan

- 160 existing + 9 new examples pass (`169 examples, 0 failures`)
- `crystal tool format --check src spec scripts` clean
- Each defect verified by hand against a build of `main` before the fix and after
- README documents the URL-list format rules and the new `file -` / process-substitution usage