### PR TITLE
fix(url,sitemap): follow redirects, honor <base href>, and limit sitemap discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ spec/
 - Output surface is stable: CLI flags, subcommands, and JSON/YAML/TOML/CSV shapes match v1 Ruby. The golden files in `spec/compat/golden/` lock this contract.
 - Resolved URLs must preserve the base URL's port. Port preservation is delegated to `base_uri.resolve` in `utils.cr::generate_url`; the regression specs live in `spec/deadfinder/utils_spec.cr` ("preserves non-default port…"). This was a v1 pain point; don't regress.
 - Silent default is `false` — the CLI emits logs by default. `-s` / `--silent` opts in.
+- Redirects are followed when fetching a **document** (a scan target page, a sitemap) but never when **checking a link** — there the `30x` is the result `--include30x` acts on. `HttpClient.fetch` takes the hop count per call site; `runner.cr::check_url` deliberately passes none. The regression spec is `spec/deadfinder/runner_spec.cr` ("still reports link redirects verbatim without following them").
 
 ## CI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,23 @@ All notable changes are documented here. Format follows [Keep a Changelog](https
 
 ## [Unreleased]
 
-### Fixed
-- macOS release tarballs now bundle Homebrew-linked runtime libraries (OpenSSL, libyaml, pcre2, bdw-gc) next to the binary so direct-download installs work without a local Homebrew dependency tree.
+### Added
+- Sitemap fetching transparently inflates gzip-compressed documents, so a `sitemap.xml.gz` served as `application/gzip` (no `Content-Encoding`) is parsed instead of failing with an XML error.
+- `-H`/`--headers` now applies to the sitemap request too, so a sitemap behind auth or a custom edge header can be fetched.
 
 ### Changed
+- Scanning a page (`url`/`file`/`pipe` targets and sitemap documents) follows up to 5 redirect hops. Relative links resolve against the page's **final** location, while the report stays keyed by the target you asked for. Link status checks are unchanged — they still report the `30x` verbatim, which is what `--include30x` acts on. Credentials (`Authorization`, `Cookie`, `Proxy-Authorization`) are dropped when a redirect crosses origins.
 - Multi-target scans (`pipe`/`file`/`sitemap`) now attribute a shared broken link to **every** page that references it, not just the first page scanned, and per-target coverage counts each page's own links. Internally the global "already-seen" URL set became a URL→status cache, so each link is still fetched at most once. Previously a 404 referenced by pages A and B was reported only under A and skewed B's coverage.
 
 ### Fixed
+- macOS release tarballs now bundle Homebrew-linked runtime libraries (OpenSSL, libyaml, pcre2, bdw-gc) next to the binary so direct-download installs work without a local Homebrew dependency tree.
+- `url`/`sitemap` no longer silently report nothing when the target redirects. Previously the `30x` body was parsed as the page (zero links discovered, no message) and a redirected sitemap failed outright with `HTTP 301`.
+- Relative links are resolved against `<base href>` when the document declares one, matching browser behaviour, instead of always resolving against the page URL.
+- Links that differ only by fragment (`/guide#install`, `/guide#usage`) now cost a single request — the fragment is never sent to the server — while both still appear in the report.
+- A sitemap index containing relative `<loc>` entries resolves them against the parent sitemap instead of failing with "URI is missing a host".
+- `--limit` stops sitemap discovery as soon as enough URLs are collected, instead of downloading every child sitemap in a sitemap index and discarding the surplus. The "Found N URLs" line now says when discovery stopped early.
+- `deadfinder url example.com` (or `sitemap example.com/sitemap.xml`) fails immediately with an actionable message and a non-zero exit code instead of a cryptic `[URI is missing a host]` mid-scan.
+- A target page that answers with a non-2xx status is reported, so links extracted from an error page are no longer mistaken for the real page's links. A page with no links at all now says so rather than logging nothing.
 - `--concurrency 0` (or any value `< 1`) no longer hangs forever. The CLI rejects it up front and the runner defensively clamps to at least one worker. `--timeout`, `--limit`, and `--output_format` are likewise validated instead of silently hanging, failing every request, or emitting an unexpected format.
 - `file` subcommand prints a clear "file not found" error instead of dumping a Crystal stack trace for a missing path.
 - Sitemap parsing no longer scans child-sitemap `.xml` files as if they were HTML pages (sitemap-index double-processing), and extracts `<loc>` namespace-agnostically so the legacy Google `0.84` sitemap namespace is no longer silently dropped.

--- a/spec/deadfinder/http_client_spec.cr
+++ b/spec/deadfinder/http_client_spec.cr
@@ -98,4 +98,175 @@ describe Deadfinder::HttpClient do
       Deadfinder::HttpClient.absolute_uri(uri).should eq("http://example.com/path?q=1")
     end
   end
+
+  describe ".request_path" do
+    it "defaults an empty path to /" do
+      Deadfinder::HttpClient.request_path(URI.parse("http://example.com"), default_test_options).should eq("/")
+    end
+
+    it "keeps the query string" do
+      Deadfinder::HttpClient.request_path(URI.parse("http://example.com/a?b=1"), default_test_options)
+        .should eq("/a?b=1")
+    end
+
+    it "uses an absolute URI when a proxy is configured for plain http" do
+      options = default_test_options
+      options.proxy = "http://127.0.0.1:8080"
+      Deadfinder::HttpClient.request_path(URI.parse("http://example.com/a"), options)
+        .should eq("http://example.com/a")
+    end
+
+    it "keeps origin-form for https even behind a proxy (CONNECT tunnel)" do
+      options = default_test_options
+      options.proxy = "http://127.0.0.1:8080"
+      Deadfinder::HttpClient.request_path(URI.parse("https://example.com/a"), options).should eq("/a")
+    end
+  end
+
+  describe ".build_headers" do
+    it "parses headers and applies the default user agent" do
+      headers = Deadfinder::HttpClient.build_headers(["X-Test: 1"], "UA/1")
+      headers["X-Test"].should eq("1")
+      headers["User-Agent"].should eq("UA/1")
+    end
+
+    it "lets an explicit User-Agent header win" do
+      headers = Deadfinder::HttpClient.build_headers(["User-Agent: Custom"], "UA/1")
+      headers["User-Agent"].should eq("Custom")
+    end
+  end
+
+  describe ".decompress_if_gzip" do
+    it "inflates a gzip body" do
+      io = IO::Memory.new
+      Compress::Gzip::Writer.open(io) { |gz| gz.print "<urlset/>" }
+      Deadfinder::HttpClient.decompress_if_gzip(String.new(io.to_slice)).should eq("<urlset/>")
+    end
+
+    it "returns non-gzip bodies untouched" do
+      Deadfinder::HttpClient.decompress_if_gzip("<urlset/>").should eq("<urlset/>")
+    end
+
+    it "returns the body untouched when the gzip stream is corrupt" do
+      corrupt = String.new(Bytes[0x1f, 0x8b, 0x08, 0x00, 0x99, 0x99])
+      Deadfinder::HttpClient.decompress_if_gzip(corrupt).should eq(corrupt)
+    end
+  end
+
+  describe ".fetch" do
+    before_each { WebMock.reset }
+
+    it "returns the redirect response untouched when max_redirects is 0" do
+      WebMock.stub(:get, "http://fetch.test/a")
+        .to_return(status: 302, headers: {"Location" => "http://fetch.test/b"})
+
+      response, final = Deadfinder::HttpClient.fetch(
+        URI.parse("http://fetch.test/a"), default_test_options, HTTP::Headers.new)
+
+      response.status_code.should eq(302)
+      final.to_s.should eq("http://fetch.test/a")
+    end
+
+    it "follows redirects and reports the final URI" do
+      WebMock.stub(:get, "http://fetch.test/a")
+        .to_return(status: 301, headers: {"Location" => "/b"})
+      WebMock.stub(:get, "http://fetch.test/b").to_return(status: 200, body: "done")
+
+      response, final = Deadfinder::HttpClient.fetch(
+        URI.parse("http://fetch.test/a"), default_test_options, HTTP::Headers.new, 5)
+
+      response.status_code.should eq(200)
+      response.body.should eq("done")
+      final.to_s.should eq("http://fetch.test/b")
+    end
+
+    it "stops at the hop limit instead of following forever" do
+      hops = 0
+      WebMock.stub(:get, /^http:\/\/hops\.test\//).to_return do |request|
+        hops += 1
+        HTTP::Client::Response.new(302, body: "", headers: HTTP::Headers{"Location" => "/#{hops}"})
+      end
+
+      response, _ = Deadfinder::HttpClient.fetch(
+        URI.parse("http://hops.test/"), default_test_options, HTTP::Headers.new, 3)
+
+      response.status_code.should eq(302)
+      hops.should eq(4) # initial request + 3 followed hops
+    end
+
+    it "stops on a redirect loop" do
+      requests = 0
+      WebMock.stub(:get, "http://loop.test/a").to_return do
+        requests += 1
+        HTTP::Client::Response.new(302, body: "", headers: HTTP::Headers{"Location" => "http://loop.test/b"})
+      end
+      WebMock.stub(:get, "http://loop.test/b").to_return do
+        requests += 1
+        HTTP::Client::Response.new(302, body: "", headers: HTTP::Headers{"Location" => "http://loop.test/a"})
+      end
+
+      Deadfinder::HttpClient.fetch(
+        URI.parse("http://loop.test/a"), default_test_options, HTTP::Headers.new, 5)
+
+      requests.should eq(2)
+    end
+
+    it "does not follow a redirect to a non-http scheme" do
+      WebMock.stub(:get, "http://scheme.test/a")
+        .to_return(status: 302, headers: {"Location" => "ftp://scheme.test/file"})
+
+      response, final = Deadfinder::HttpClient.fetch(
+        URI.parse("http://scheme.test/a"), default_test_options, HTTP::Headers.new, 5)
+
+      response.status_code.should eq(302)
+      final.to_s.should eq("http://scheme.test/a")
+    end
+
+    it "keeps credentials on a same-origin redirect" do
+      seen : String? = nil
+      WebMock.stub(:get, "http://same.test/a")
+        .to_return(status: 302, headers: {"Location" => "http://same.test/b"})
+      WebMock.stub(:get, "http://same.test/b").to_return do |request|
+        seen = request.headers["Authorization"]?
+        HTTP::Client::Response.new(200, body: "")
+      end
+
+      Deadfinder::HttpClient.fetch(URI.parse("http://same.test/a"), default_test_options,
+        HTTP::Headers{"Authorization" => "Bearer secret"}, 5)
+
+      seen.should eq("Bearer secret")
+    end
+
+    it "drops credentials when the redirect crosses origins" do
+      seen : String? = "unset"
+      WebMock.stub(:get, "http://origin.test/a")
+        .to_return(status: 302, headers: {"Location" => "http://other.test/b"})
+      WebMock.stub(:get, "http://other.test/b").to_return do |request|
+        seen = request.headers["Authorization"]?
+        HTTP::Client::Response.new(200, body: "")
+      end
+
+      headers = HTTP::Headers{"Authorization" => "Bearer secret", "X-Trace" => "keep"}
+      Deadfinder::HttpClient.fetch(URI.parse("http://origin.test/a"), default_test_options, headers, 5)
+
+      seen.should be_nil
+      # The caller's headers must not be mutated by the strip.
+      headers["Authorization"].should eq("Bearer secret")
+    end
+
+    it "keeps non-sensitive headers across an origin change" do
+      seen : String? = nil
+      WebMock.stub(:get, "http://origin2.test/a")
+        .to_return(status: 302, headers: {"Location" => "http://other2.test/b"})
+      WebMock.stub(:get, "http://other2.test/b").to_return do |request|
+        seen = request.headers["X-Trace"]?
+        HTTP::Client::Response.new(200, body: "")
+      end
+
+      Deadfinder::HttpClient.fetch(URI.parse("http://origin2.test/a"), default_test_options,
+        HTTP::Headers{"Authorization" => "Bearer secret", "X-Trace" => "keep"}, 5)
+
+      seen.should eq("keep")
+    end
+  end
 end

--- a/spec/deadfinder/runner_spec.cr
+++ b/spec/deadfinder/runner_spec.cr
@@ -451,9 +451,9 @@ describe Deadfinder::Runner do
       options = default_test_options
       args = make_runner_args
 
-      jobs = Channel(String).new(10)
-      results = Channel(String).new(10)
-      jobs.send(url)
+      jobs = Channel(Tuple(String, Array(String))).new(10)
+      results = Channel(Nil).new(10)
+      jobs.send(job_for(url))
       jobs.close
 
       runner.worker(1, jobs, results, target, options, **args)
@@ -471,9 +471,9 @@ describe Deadfinder::Runner do
       options = default_test_options
       args = make_runner_args
 
-      jobs = Channel(String).new(10)
-      results = Channel(String).new(10)
-      jobs.send(url)
+      jobs = Channel(Tuple(String, Array(String))).new(10)
+      results = Channel(Nil).new(10)
+      jobs.send(job_for(url))
       jobs.close
 
       runner.worker(1, jobs, results, target, options, **args)
@@ -491,9 +491,9 @@ describe Deadfinder::Runner do
       options = default_test_options
       args = make_runner_args
 
-      jobs = Channel(String).new(10)
-      results = Channel(String).new(10)
-      jobs.send(url)
+      jobs = Channel(Tuple(String, Array(String))).new(10)
+      results = Channel(Nil).new(10)
+      jobs.send(job_for(url))
       jobs.close
 
       runner.worker(1, jobs, results, target, options, **args)
@@ -512,9 +512,9 @@ describe Deadfinder::Runner do
       options.include30x = false
       args = make_runner_args
 
-      jobs = Channel(String).new(10)
-      results = Channel(String).new(10)
-      jobs.send(url)
+      jobs = Channel(Tuple(String, Array(String))).new(10)
+      results = Channel(Nil).new(10)
+      jobs.send(job_for(url))
       jobs.close
 
       runner.worker(1, jobs, results, target, options, **args)
@@ -533,9 +533,9 @@ describe Deadfinder::Runner do
       options.include30x = true
       args = make_runner_args
 
-      jobs = Channel(String).new(10)
-      results = Channel(String).new(10)
-      jobs.send(url)
+      jobs = Channel(Tuple(String, Array(String))).new(10)
+      results = Channel(Nil).new(10)
+      jobs.send(job_for(url))
       jobs.close
 
       runner.worker(1, jobs, results, target, options, **args)
@@ -554,9 +554,9 @@ describe Deadfinder::Runner do
       # Pre-populate the status cache as if a previous page already checked it.
       args[:status_cache][url] = 404
 
-      jobs = Channel(String).new(10)
-      results = Channel(String).new(10)
-      jobs.send(url)
+      jobs = Channel(Tuple(String, Array(String))).new(10)
+      results = Channel(Nil).new(10)
+      jobs.send(job_for(url))
       jobs.close
 
       runner.worker(1, jobs, results, target, options, **args)
@@ -576,11 +576,11 @@ describe Deadfinder::Runner do
       options = default_test_options
       args = make_runner_args
 
-      jobs = Channel(String).new(10)
-      results = Channel(String).new(10)
-      jobs.send("http://example.com/a")
-      jobs.send("http://example.com/b")
-      jobs.send("http://example.com/c")
+      jobs = Channel(Tuple(String, Array(String))).new(10)
+      results = Channel(Nil).new(10)
+      jobs.send(job_for("http://example.com/a"))
+      jobs.send(job_for("http://example.com/b"))
+      jobs.send(job_for("http://example.com/c"))
       jobs.close
 
       runner.worker(1, jobs, results, target, options, **args)
@@ -603,11 +603,11 @@ describe Deadfinder::Runner do
       options.coverage = true
       args = make_runner_args
 
-      jobs = Channel(String).new(10)
-      results = Channel(String).new(10)
-      jobs.send("http://example.com/ok")
-      jobs.send("http://example.com/not-found")
-      jobs.send("http://example.com/server-err")
+      jobs = Channel(Tuple(String, Array(String))).new(10)
+      results = Channel(Nil).new(10)
+      jobs.send(job_for("http://example.com/ok"))
+      jobs.send(job_for("http://example.com/not-found"))
+      jobs.send(job_for("http://example.com/server-err"))
       jobs.close
 
       runner.worker(1, jobs, results, target, options, **args)
@@ -633,9 +633,9 @@ describe Deadfinder::Runner do
       options.worker_headers = ["Authorization: Bearer token123"]
       args = make_runner_args
 
-      jobs = Channel(String).new(10)
-      results = Channel(String).new(10)
-      jobs.send(url)
+      jobs = Channel(Tuple(String, Array(String))).new(10)
+      results = Channel(Nil).new(10)
+      jobs.send(job_for(url))
       jobs.close
 
       runner.worker(1, jobs, results, target, options, **args)
@@ -656,9 +656,9 @@ describe Deadfinder::Runner do
       options.worker_headers = ["User-Agent: my-custom-agent"]
       args = make_runner_args
 
-      jobs = Channel(String).new(10)
-      results = Channel(String).new(10)
-      jobs.send(url)
+      jobs = Channel(Tuple(String, Array(String))).new(10)
+      results = Channel(Nil).new(10)
+      jobs.send(job_for(url))
       jobs.close
 
       runner.worker(1, jobs, results, target, options, **args)
@@ -679,9 +679,9 @@ describe Deadfinder::Runner do
       options = default_test_options
       args = make_runner_args
 
-      jobs = Channel(String).new(10)
-      results = Channel(String).new(10)
-      jobs.send(url)
+      jobs = Channel(Tuple(String, Array(String))).new(10)
+      results = Channel(Nil).new(10)
+      jobs.send(job_for(url))
       jobs.close
 
       runner.worker(1, jobs, results, target, options, **args)
@@ -701,9 +701,9 @@ describe Deadfinder::Runner do
       options.coverage = true
       args = make_runner_args
 
-      jobs = Channel(String).new(10)
-      results = Channel(String).new(10)
-      jobs.send(url)
+      jobs = Channel(Tuple(String, Array(String))).new(10)
+      results = Channel(Nil).new(10)
+      jobs.send(job_for(url))
       jobs.close
 
       runner.worker(1, jobs, results, target, options, **args)
@@ -712,6 +712,122 @@ describe Deadfinder::Runner do
       cov.total.should eq 1
       cov.dead.should eq 1
       cov.status_counts["error"].should eq 1
+    end
+  end
+end
+
+describe Deadfinder::Runner do
+  before_each { WebMock.reset }
+
+  describe "#run redirect handling" do
+    it "follows a redirected target page instead of parsing an empty body" do
+      WebMock.stub(:get, "http://moved.test/")
+        .to_return(status: 301, headers: {"Location" => "http://moved.test/home"})
+      WebMock.stub(:get, "http://moved.test/home")
+        .to_return(body: %(<html><body><a href="http://moved.test/dead">d</a></body></html>))
+      WebMock.stub(:get, "http://moved.test/dead").to_return(status: 404)
+
+      args = make_runner_args
+      Deadfinder::Runner.new.run("http://moved.test/", default_test_options, **args)
+
+      # Output stays keyed by the target the user asked for.
+      args[:output]["http://moved.test/"].should contain "http://moved.test/dead"
+    end
+
+    it "resolves relative links against the post-redirect location" do
+      WebMock.stub(:get, "http://rel.test/old")
+        .to_return(status: 302, headers: {"Location" => "http://rel.test/new/page"})
+      WebMock.stub(:get, "http://rel.test/new/page")
+        .to_return(body: %(<html><body><a href="sibling">s</a></body></html>))
+      WebMock.stub(:get, "http://rel.test/new/sibling").to_return(status: 404)
+
+      args = make_runner_args
+      Deadfinder::Runner.new.run("http://rel.test/old", default_test_options, **args)
+
+      args[:output]["http://rel.test/old"].should eq ["http://rel.test/new/sibling"]
+    end
+
+    it "still reports link redirects verbatim without following them" do
+      followed = false
+      WebMock.stub(:get, "http://link.test/")
+        .to_return(body: %(<html><body><a href="http://link.test/moved">m</a></body></html>))
+      WebMock.stub(:get, "http://link.test/moved")
+        .to_return(status: 301, headers: {"Location" => "http://link.test/final"})
+      WebMock.stub(:get, "http://link.test/final").to_return do
+        followed = true
+        HTTP::Client::Response.new(200, body: "")
+      end
+
+      options = default_test_options
+      options.include30x = true
+      args = make_runner_args
+      Deadfinder::Runner.new.run("http://link.test/", options, **args)
+
+      followed.should be_false
+      args[:output]["http://link.test/"].should contain "http://link.test/moved"
+    end
+  end
+
+  describe "#run base href handling" do
+    it "resolves relative links against <base href>" do
+      html = %(<html><head><base href="http://base.test/docs/"></head><body><a href="guide">g</a></body></html>)
+      WebMock.stub(:get, "http://base.test/index.html").to_return(body: html)
+      WebMock.stub(:get, "http://base.test/docs/guide").to_return(status: 404)
+
+      args = make_runner_args
+      Deadfinder::Runner.new.run("http://base.test/index.html", default_test_options, **args)
+
+      args[:output]["http://base.test/index.html"].should eq ["http://base.test/docs/guide"]
+    end
+
+    it "accepts a relative <base href>" do
+      html = %(<html><head><base href="/docs/"></head><body><a href="guide">g</a></body></html>)
+      WebMock.stub(:get, "http://relbase.test/a/index.html").to_return(body: html)
+      WebMock.stub(:get, "http://relbase.test/docs/guide").to_return(status: 404)
+
+      args = make_runner_args
+      Deadfinder::Runner.new.run("http://relbase.test/a/index.html", default_test_options, **args)
+
+      args[:output]["http://relbase.test/a/index.html"].should eq ["http://relbase.test/docs/guide"]
+    end
+
+    it "ignores an empty <base href> and falls back to the page URL" do
+      html = %(<html><head><base href=""></head><body><a href="guide">g</a></body></html>)
+      WebMock.stub(:get, "http://emptybase.test/a/index.html").to_return(body: html)
+      WebMock.stub(:get, "http://emptybase.test/a/guide").to_return(status: 404)
+
+      args = make_runner_args
+      Deadfinder::Runner.new.run("http://emptybase.test/a/index.html", default_test_options, **args)
+
+      args[:output]["http://emptybase.test/a/index.html"].should eq ["http://emptybase.test/a/guide"]
+    end
+  end
+
+  describe "#run fragment handling" do
+    it "requests a URL once for links that differ only by fragment" do
+      requests = 0
+      html = %(<html><body>
+        <a href="http://frag.test/guide#install">i</a>
+        <a href="http://frag.test/guide#usage">u</a>
+      </body></html>)
+      WebMock.stub(:get, "http://frag.test/index.html").to_return(body: html)
+      WebMock.stub(:get, "http://frag.test/guide").to_return do
+        requests += 1
+        HTTP::Client::Response.new(404, body: "")
+      end
+
+      options = default_test_options
+      options.coverage = true
+      args = make_runner_args
+      Deadfinder::Runner.new.run("http://frag.test/index.html", options, **args)
+
+      requests.should eq 1
+      # Both link instances are still reported, so the user can find each one.
+      args[:output]["http://frag.test/index.html"].sort.should eq [
+        "http://frag.test/guide#install",
+        "http://frag.test/guide#usage",
+      ]
+      args[:coverage_data]["http://frag.test/index.html"].total.should eq 2
     end
   end
 end

--- a/spec/deadfinder/utils_spec.cr
+++ b/spec/deadfinder/utils_spec.cr
@@ -146,3 +146,31 @@ describe "Deadfinder.ignore_scheme?" do
     Deadfinder.ignore_scheme?("page.html").should be_false
   end
 end
+
+describe "Deadfinder.http_target_error" do
+  it "accepts absolute http and https URLs" do
+    Deadfinder.http_target_error("http://example.com").should be_nil
+    Deadfinder.http_target_error("https://example.com/a?b=1").should be_nil
+    Deadfinder.http_target_error("  https://example.com  ").should be_nil
+  end
+
+  it "rejects an empty target" do
+    Deadfinder.http_target_error("   ").should eq "empty URL"
+  end
+
+  it "suggests a scheme when one is missing" do
+    reason = Deadfinder.http_target_error("example.com/sitemap.xml")
+    reason.should_not be_nil
+    reason.not_nil!.should contain "https://example.com/sitemap.xml"
+  end
+
+  it "rejects a non-http scheme" do
+    reason = Deadfinder.http_target_error("ftp://example.com/a")
+    reason.not_nil!.should contain "unsupported scheme"
+  end
+
+  it "rejects an http URL with no host" do
+    reason = Deadfinder.http_target_error("http:///a")
+    reason.not_nil!.should contain "missing host"
+  end
+end

--- a/spec/deadfinder_spec.cr
+++ b/spec/deadfinder_spec.cr
@@ -71,6 +71,10 @@ describe Deadfinder do
         tempfile.delete
       end
     end
+    it "reports a scheme-less target instead of scanning" do
+      Deadfinder.run_url("bad.test/index.html", default_test_options)
+      Deadfinder.output.should be_empty
+    end
   end
 
   describe "#run_file" do
@@ -387,6 +391,119 @@ describe Deadfinder do
       Deadfinder.output["http://idx.test/sub.xml"]?.should be_nil
       Deadfinder.output["http://idx.test/page1"]?.should_not be_nil
       Deadfinder.output["http://idx.test/page1"].should contain "http://idx.test/dead"
+    end
+
+    it "follows a redirect to the real sitemap document" do
+      sitemap_xml = <<-XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <url><loc>http://sm-redirect.test/page1</loc></url>
+        </urlset>
+      XML
+
+      WebMock.stub(:get, "http://sm-redirect.test/sitemap.xml")
+        .to_return(status: 301, headers: {"Location" => "/sitemap_index.xml"})
+      WebMock.stub(:get, "http://sm-redirect.test/sitemap_index.xml").to_return(body: sitemap_xml)
+      WebMock.stub(:get, "http://sm-redirect.test/page1")
+        .to_return(body: %(<html><body><a href="http://sm-redirect.test/dead">d</a></body></html>))
+      WebMock.stub(:get, "http://sm-redirect.test/dead").to_return(status: 404)
+
+      Deadfinder.run_sitemap("http://sm-redirect.test/sitemap.xml", default_test_options)
+
+      Deadfinder.output["http://sm-redirect.test/page1"].should contain "http://sm-redirect.test/dead"
+    end
+
+    it "resolves relative <loc> values against the sitemap location" do
+      sitemap_xml = <<-XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <url><loc>/page1</loc></url>
+        </urlset>
+      XML
+
+      WebMock.stub(:get, "http://sm-rel.test/sitemap.xml").to_return(body: sitemap_xml)
+      WebMock.stub(:get, "http://sm-rel.test/page1")
+        .to_return(body: %(<html><body><a href="http://sm-rel.test/dead">d</a></body></html>))
+      WebMock.stub(:get, "http://sm-rel.test/dead").to_return(status: 404)
+
+      Deadfinder.run_sitemap("http://sm-rel.test/sitemap.xml", default_test_options)
+
+      Deadfinder.output["http://sm-rel.test/page1"].should contain "http://sm-rel.test/dead"
+    end
+
+    it "resolves a relative child sitemap in a sitemap index" do
+      index_xml = <<-XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <sitemap><loc>/sub.xml</loc></sitemap>
+        </sitemapindex>
+      XML
+      sub_xml = <<-XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <url><loc>http://sm-relidx.test/page1</loc></url>
+        </urlset>
+      XML
+
+      WebMock.stub(:get, "http://sm-relidx.test/index.xml").to_return(body: index_xml)
+      WebMock.stub(:get, "http://sm-relidx.test/sub.xml").to_return(body: sub_xml)
+      WebMock.stub(:get, "http://sm-relidx.test/page1")
+        .to_return(body: %(<html><body><a href="http://sm-relidx.test/dead">d</a></body></html>))
+      WebMock.stub(:get, "http://sm-relidx.test/dead").to_return(status: 404)
+
+      Deadfinder.run_sitemap("http://sm-relidx.test/index.xml", default_test_options)
+
+      Deadfinder.output["http://sm-relidx.test/page1"].should contain "http://sm-relidx.test/dead"
+    end
+
+    it "parses a gzip-compressed sitemap body" do
+      sitemap_xml = <<-XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <url><loc>http://sm-gz.test/page1</loc></url>
+        </urlset>
+      XML
+      io = IO::Memory.new
+      Compress::Gzip::Writer.open(io) { |gz| gz.print sitemap_xml }
+
+      WebMock.stub(:get, "http://sm-gz.test/sitemap.xml.gz").to_return(body: String.new(io.to_slice))
+      WebMock.stub(:get, "http://sm-gz.test/page1")
+        .to_return(body: %(<html><body><a href="http://sm-gz.test/dead">d</a></body></html>))
+      WebMock.stub(:get, "http://sm-gz.test/dead").to_return(status: 404)
+
+      Deadfinder.run_sitemap("http://sm-gz.test/sitemap.xml.gz", default_test_options)
+
+      Deadfinder.output["http://sm-gz.test/page1"].should contain "http://sm-gz.test/dead"
+    end
+
+    it "stops downloading child sitemaps once --limit is satisfied" do
+      index_xml = String.build do |io|
+        io << %(<?xml version="1.0" encoding="UTF-8"?>)
+        io << %(<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">)
+        3.times { |i| io << "<sitemap><loc>http://sm-limit.test/sub#{i}.xml</loc></sitemap>" }
+        io << "</sitemapindex>"
+      end
+
+      WebMock.stub(:get, "http://sm-limit.test/index.xml").to_return(body: index_xml)
+      fetched = [] of String
+      3.times do |i|
+        WebMock.stub(:get, "http://sm-limit.test/sub#{i}.xml").to_return do
+          fetched << "sub#{i}"
+          HTTP::Client::Response.new(200, body: %(<urlset><url><loc>http://sm-limit.test/page#{i}</loc></url></urlset>))
+        end
+        WebMock.stub(:get, "http://sm-limit.test/page#{i}").to_return(body: "<html></html>")
+      end
+
+      options = default_test_options
+      options.limit = 1
+      Deadfinder.run_sitemap("http://sm-limit.test/index.xml", options)
+
+      fetched.should eq ["sub0"]
+    end
+
+    it "reports a scheme-less sitemap target instead of scanning" do
+      Deadfinder.run_sitemap("sm-bad.test/sitemap.xml", default_test_options)
+      Deadfinder.output.should be_empty
     end
 
     it "parses a sitemap using the legacy Google 0.84 namespace" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -27,3 +27,9 @@ def make_runner_args
     mutex:         Mutex.new,
   }
 end
+
+# Worker jobs are `{request URL, links that resolved to it}` pairs: one request
+# serves every link that differs only by fragment.
+def job_for(url : String)
+  {url, [url]}
+end

--- a/src/deadfinder.cr
+++ b/src/deadfinder.cr
@@ -135,93 +135,163 @@ module Deadfinder
 
   def self.run_url(url : String, options : Options)
     Deadfinder::Logger.apply_options(options)
-    run_with_target(url, options)
+    if reason = http_target_error(url)
+      Deadfinder::Logger.error "Cannot scan target: #{reason}"
+      return
+    end
+    run_with_target(url.strip, options)
     gen_output(options)
   end
 
   def self.run_sitemap(sitemap_url : String, options : Options)
     Deadfinder::Logger.apply_options(options)
+    if reason = http_target_error(sitemap_url)
+      Deadfinder::Logger.error "Cannot fetch sitemap: #{reason}"
+      return
+    end
+
     app = Runner.new
-    urls = parse_sitemap(sitemap_url, options).uniq
-    urls = urls.first(options.limit) if options.limit > 0
-    Deadfinder::Logger.info "Found #{urls.size} URLs from #{sitemap_url}"
+    collector = SitemapCollector.new(options.limit)
+    parse_sitemap(sitemap_url.strip, options, collector)
+    urls = collector.urls
+
+    if collector.truncated?
+      Deadfinder::Logger.info "Found #{urls.size} URLs from #{sitemap_url} (stopped early at --limit #{options.limit})"
+    else
+      Deadfinder::Logger.info "Found #{urls.size} URLs from #{sitemap_url}"
+    end
+
     urls.each do |url|
-      turl = generate_url(url, sitemap_url)
-      run_with_target(turl, options, app) if turl
+      run_with_target(url, options, app)
     end
     gen_output(options)
   end
 
-  private def self.parse_sitemap(sitemap_url : String, options : Options,
-                                 depth : Int32 = 0,
-                                 visited : Set(String) = Set(String).new) : Array(String)
-    urls = [] of String
+  # Accumulates state across the recursive sitemap walk: the ordered, unique
+  # page URLs found so far, the sitemap documents already fetched (cycle
+  # guard), and the `--limit` cutoff. Threading the limit through the walk lets
+  # a huge sitemap index stop downloading children as soon as enough URLs are
+  # in hand, instead of fetching every child and throwing the surplus away.
+  private class SitemapCollector
+    getter urls = [] of String
+    getter? truncated : Bool = false
 
+    def initialize(@limit : Int32 = 0)
+      @seen = Set(String).new
+      @visited = Set(String).new
+    end
+
+    def add(url : String) : Nil
+      return if @seen.includes?(url)
+      if full?
+        @truncated = true
+        return
+      end
+      @seen << url
+      @urls << url
+    end
+
+    def full? : Bool
+      @limit > 0 && @urls.size >= @limit
+    end
+
+    def mark_truncated : Nil
+      @truncated = true
+    end
+
+    # Returns false when this sitemap document has already been fetched.
+    def visit(sitemap_url : String) : Bool
+      @visited.add?(sitemap_url)
+    end
+  end
+
+  private def self.parse_sitemap(sitemap_url : String, options : Options,
+                                 collector : SitemapCollector,
+                                 depth : Int32 = 0) : Nil
+    if collector.full?
+      collector.mark_truncated
+      return
+    end
     if depth >= MAX_SITEMAP_DEPTH
       Deadfinder::Logger.error "Sitemap depth limit (#{MAX_SITEMAP_DEPTH}) reached at #{sitemap_url}"
-      return urls
+      return
     end
-    if visited.includes?(sitemap_url)
+    unless collector.visit(sitemap_url)
       Deadfinder::Logger.error "Sitemap cycle detected at #{sitemap_url}"
-      return urls
+      return
     end
-    visited << sitemap_url
 
     begin
       uri = URI.parse(sitemap_url)
-      client = HttpClient.create(uri, options)
-      begin
-        headers = HTTP::Headers.new
-        headers["User-Agent"] = options.user_agent
-        req_path = if HttpClient.proxy_configured?(options) && uri.scheme == "http"
-                     HttpClient.absolute_uri(uri)
-                   else
-                     path = uri.path.presence || "/"
-                     uri.query.presence ? "#{path}?#{uri.query}" : path
-                   end
-        response = client.get(req_path, headers: headers)
+      headers = HttpClient.build_headers(options.headers, options.user_agent)
+      # Sitemaps very commonly sit behind a redirect (http -> https, apex -> www,
+      # /sitemap.xml -> /sitemap_index.xml). Follow it instead of reporting the
+      # 30x itself as a fetch failure.
+      response, final_uri = HttpClient.fetch(uri, options, headers, HttpClient::MAX_REDIRECTS)
 
-        if response.status_code != 200
-          Deadfinder::Logger.error "Failed to fetch sitemap #{sitemap_url}: HTTP #{response.status_code}"
-          return urls
-        end
-
-        doc = XML.parse(response.body)
-      ensure
-        client.close
+      unless response.status.success?
+        Deadfinder::Logger.error "Failed to fetch sitemap #{sitemap_url}: HTTP #{response.status_code}"
+        return
       end
+
+      # Relative <loc> values (and relative child-sitemap references) resolve
+      # against the document's final location, not the address originally
+      # requested.
+      base = final_uri.to_s
+      doc = XML.parse(HttpClient.decompress_if_gzip(response.body))
 
       # Namespace-agnostic extraction via local-name(): handles the standard
       # 0.9 namespace, the legacy Google 0.84 namespace, and namespace-free
       # documents uniformly. Page URLs are scoped under <url> and child
       # sitemaps under <sitemap> so a sitemap-index's <sitemap><loc> entries are
       # NOT mis-collected as page targets (which previously double-fetched them).
+      found_before = collector.urls.size
       doc.xpath_nodes("//*[local-name()='url']/*[local-name()='loc']").each do |node|
-        urls << node.text.strip unless node.text.strip.empty?
+        collect_sitemap_url(collector, node.text, base, sitemap_url)
       end
 
       # Check for sitemap index (recursive sitemaps)
       sitemap_locs = [] of String
       doc.xpath_nodes("//*[local-name()='sitemap']/*[local-name()='loc']").each do |node|
-        sitemap_locs << node.text.strip unless node.text.strip.empty?
+        text = node.text.strip
+        sitemap_locs << text unless text.empty?
       end
 
       # Tolerate malformed sitemaps that put <loc> at the top level (no <url>
-      # wrapper). Only used when neither a urlset nor a sitemap index matched,
-      # so it cannot reintroduce the index double-processing bug.
-      if urls.empty? && sitemap_locs.empty?
+      # wrapper). Only used when *this document* matched neither a urlset nor a
+      # sitemap index, so it cannot reintroduce the index double-processing bug.
+      if collector.urls.size == found_before && sitemap_locs.empty?
         doc.xpath_nodes("//*[local-name()='loc']").each do |node|
-          urls << node.text.strip unless node.text.strip.empty?
+          collect_sitemap_url(collector, node.text, base, sitemap_url)
         end
       end
 
-      sitemap_locs.each do |sub_sitemap|
-        urls.concat(parse_sitemap(sub_sitemap, options, depth + 1, visited))
+      sitemap_locs.each do |loc|
+        if collector.full?
+          collector.mark_truncated
+          break
+        end
+        sub_sitemap = generate_url(loc, base)
+        unless sub_sitemap
+          Deadfinder::Logger.error "Skipping unusable child sitemap #{loc.inspect} in #{sitemap_url}"
+          next
+        end
+        parse_sitemap(sub_sitemap, options, collector, depth + 1)
       end
     rescue ex
-      Deadfinder::Logger.error "Failed to parse sitemap: #{ex.message}"
+      Deadfinder::Logger.error "Failed to parse sitemap #{sitemap_url}: #{ex.message}"
     end
-    urls
+  end
+
+  private def self.collect_sitemap_url(collector : SitemapCollector, raw : String,
+                                       base : String, sitemap_url : String) : Nil
+    text = raw.strip
+    return if text.empty?
+    if url = generate_url(text, base)
+      collector.add(url)
+    else
+      Deadfinder::Logger.debug "Skipping unusable sitemap entry #{text.inspect} in #{sitemap_url}"
+    end
   end
 
   private def self.run_with_input(options : Options, &block : -> Array(String))

--- a/src/deadfinder/cli.cr
+++ b/src/deadfinder/cli.cr
@@ -133,7 +133,12 @@ module Deadfinder
         end
       when "url"
         if positional_arg
-          Deadfinder.run_url(positional_arg.not_nil!, options)
+          target = positional_arg.not_nil!
+          if reason = Deadfinder.http_target_error(target)
+            STDERR.puts "Error: #{reason}"
+            exit 1
+          end
+          Deadfinder.run_url(target, options)
         else
           STDERR.puts "Error: url command requires a URL argument"
           STDERR.puts "Usage: deadfinder url <URL> [options]"
@@ -141,7 +146,12 @@ module Deadfinder
         end
       when "sitemap"
         if positional_arg
-          Deadfinder.run_sitemap(positional_arg.not_nil!, options)
+          target = positional_arg.not_nil!
+          if reason = Deadfinder.http_target_error(target)
+            STDERR.puts "Error: #{reason}"
+            exit 1
+          end
+          Deadfinder.run_sitemap(target, options)
         else
           STDERR.puts "Error: sitemap command requires a URL argument"
           STDERR.puts "Usage: deadfinder sitemap <SITEMAP-URL> [options]"

--- a/src/deadfinder/http_client.cr
+++ b/src/deadfinder/http_client.cr
@@ -3,18 +3,48 @@ require "openssl"
 require "uri"
 require "base64"
 require "socket"
+require "compress/gzip"
 
 module Deadfinder
   module HttpClient
+    # Redirect hops followed when fetching a *document* (a scan target page or a
+    # sitemap). Link status checks deliberately pass 0: there the 30x status is
+    # the answer being reported (see `--include30x`).
+    MAX_REDIRECTS = 5
+
+    # Headers that must not be replayed to a different origin after a redirect.
+    # Mirrors curl's default behaviour: following a redirect off-host with a
+    # user-supplied `Authorization`/`Cookie` would leak the credential.
+    CROSS_ORIGIN_SENSITIVE_HEADERS = ["Authorization", "Cookie", "Proxy-Authorization"]
+
     @@proxy_cache = {} of String => URI?
     @@proxy_cache_mutex = Mutex.new
+
+    # Parse "Name: value" header strings. Accepts ":" or ": " as the
+    # separator and trims both sides — every request the tool makes (target
+    # page, sitemap document, link check) builds its headers here so users
+    # don't hit depending-on-which-flag surprises.
+    def self.build_headers(raw : Array(String), user_agent : String) : HTTP::Headers
+      headers = HTTP::Headers.new
+      raw.each do |header|
+        name, sep, value = header.partition(':')
+        next if sep.empty?
+        name = name.strip
+        next if name.empty?
+        headers[name] = value.strip
+      end
+      # Honor a user-supplied User-Agent (HTTP::Headers is case-insensitive);
+      # only fall back to the default when none was provided.
+      headers["User-Agent"] = user_agent unless headers.has_key?("User-Agent")
+      headers
+    end
 
     def self.create(uri : URI, options : Options) : HTTP::Client
       # `presence` (not just `nil?`): `file:///etc/hosts` parses to an *empty*
       # host, which passed a nil-check and then tried to connect to ":80".
       host = uri.host.presence
       if host.nil?
-        raise ArgumentError.new("URI is missing a host")
+        raise ArgumentError.new("missing host - did you include the scheme (http:// or https://)?")
       end
       scheme = uri.scheme
       # Anything other than http/https cannot be fetched here; without this
@@ -120,6 +150,110 @@ module Deadfinder
 
     def self.proxy_configured?(options : Options) : Bool
       !options.proxy.empty?
+    end
+
+    # Request-line target for `uri`: an absolute URI when talking plain HTTP to
+    # a forward proxy, an origin-form path otherwise.
+    def self.request_path(uri : URI, options : Options) : String
+      if proxy_configured?(options) && uri.scheme == "http"
+        absolute_uri(uri)
+      else
+        path = uri.path.presence || "/"
+        if q = uri.query.presence
+          "#{path}?#{q}"
+        else
+          path
+        end
+      end
+    end
+
+    # Fetches `uri` and returns the response together with the URI it was
+    # finally served from. `max_redirects` hops of 30x `Location` are followed;
+    # with the default of 0 the redirect response itself is returned untouched.
+    #
+    # Callers need the final URI because relative links (and relative sitemap
+    # `<loc>` entries) must resolve against the post-redirect location, not
+    # against the address the user originally typed.
+    def self.fetch(uri : URI, options : Options, headers : HTTP::Headers,
+                   max_redirects : Int32 = 0) : {HTTP::Client::Response, URI}
+      current = uri
+      current_headers = headers
+      seen = Set(String).new
+      hops = 0
+
+      loop do
+        client = create(current, options)
+        response = begin
+          client.get(request_path(current, options), headers: current_headers)
+        ensure
+          client.close
+        end
+
+        return {response, current} if hops >= max_redirects || !response.status.redirection?
+
+        location = response.headers["Location"]?.try(&.strip).presence
+        # A 3xx without a usable Location (300 Multiple Choices, 304 Not
+        # Modified, or a malformed response) is the final answer.
+        return {response, current} unless location
+
+        next_uri = begin
+          current.resolve(location)
+        rescue
+          return {response, current}
+        end
+        return {response, current} unless next_uri.scheme == "http" || next_uri.scheme == "https"
+        return {response, current} unless next_uri.host
+
+        # Stop on a redirect loop rather than burning every remaining hop.
+        seen << current.to_s
+        return {response, current} if seen.includes?(next_uri.to_s)
+
+        current_headers = strip_cross_origin_headers(current_headers, current, next_uri)
+        current = next_uri
+        hops += 1
+      end
+    end
+
+    # Sitemaps are routinely published gzipped (`sitemap.xml.gz`). When the file
+    # is served as an opaque `application/gzip` body there is no
+    # `Content-Encoding` for HTTP::Client to transparently undo, so detect the
+    # gzip magic bytes and inflate here. Returns the body unchanged when it is
+    # not gzip, or when it cannot be inflated.
+    def self.decompress_if_gzip(body : String) : String
+      bytes = body.to_slice
+      return body unless bytes.size >= 2 && bytes[0] == 0x1f && bytes[1] == 0x8b
+
+      begin
+        Compress::Gzip::Reader.open(IO::Memory.new(bytes)) do |gz|
+          gz.gets_to_end
+        end
+      rescue ex
+        Deadfinder::Logger.debug "Gzip decompression failed: #{ex.message}"
+        body
+      end
+    end
+
+    private def self.strip_cross_origin_headers(headers : HTTP::Headers, from : URI, to : URI) : HTTP::Headers
+      return headers if same_origin?(from, to)
+      return headers unless CROSS_ORIGIN_SENSITIVE_HEADERS.any? { |name| headers.has_key?(name) }
+
+      # Build a fresh instance rather than duplicating: HTTP::Headers is a
+      # struct wrapping a Hash, so `dup` would share that Hash and deleting
+      # from the copy would strip the caller's headers too.
+      stripped = HTTP::Headers.new
+      headers.each do |name, values|
+        next if CROSS_ORIGIN_SENSITIVE_HEADERS.any? { |sensitive| name.compare(sensitive, case_insensitive: true) == 0 }
+        values.each { |value| stripped.add(name, value) }
+      end
+      stripped
+    end
+
+    private def self.same_origin?(a : URI, b : URI) : Bool
+      a.scheme == b.scheme && a.host == b.host && effective_port(a) == effective_port(b)
+    end
+
+    private def self.effective_port(uri : URI) : Int32
+      uri.port || (uri.scheme == "https" ? 443 : 80)
     end
 
     private def self.create_direct(host : String, port : Int32?, use_ssl : Bool, options : Options) : HTTP::Client

--- a/src/deadfinder/runner.cr
+++ b/src/deadfinder/runner.cr
@@ -19,32 +19,8 @@ module Deadfinder
     # always >= 0, so -1 unambiguously marks a connection error.
     ERROR_STATUS = -1
 
-    private def request_path(uri : URI) : String
-      path = uri.path.presence || "/"
-      if q = uri.query.presence
-        "#{path}?#{q}"
-      else
-        path
-      end
-    end
-
-    # Parse "Name: value" header strings. Accepts ":" or ": " as the
-    # separator and trims both sides — keeps initial-request and worker
-    # headers using the exact same semantics so users don't hit
-    # depending-on-which-flag surprises.
     private def build_headers(raw : Array(String), user_agent : String) : HTTP::Headers
-      headers = HTTP::Headers.new
-      raw.each do |header|
-        name, sep, value = header.partition(':')
-        next if sep.empty?
-        name = name.strip
-        next if name.empty?
-        headers[name] = value.strip
-      end
-      # Honor a user-supplied User-Agent (HTTP::Headers is case-insensitive);
-      # only fall back to the default when none was provided.
-      headers["User-Agent"] = user_agent unless headers.has_key?("User-Agent")
-      headers
+      HttpClient.build_headers(raw, user_agent)
     end
 
     def run(target : String, options : Options,
@@ -57,18 +33,16 @@ module Deadfinder
       headers = build_headers(options.headers, options.user_agent)
 
       uri = URI.parse(target)
-      client = HttpClient.create(uri, options)
-      begin
-        path = if HttpClient.proxy_configured?(options) && uri.scheme == "http"
-                 HttpClient.absolute_uri(uri)
-               else
-                 request_path(uri)
-               end
-        response = client.get(path, headers: headers)
-        page = Lexbor::Parser.new(response.body)
-      ensure
-        client.close
+      # Follow redirects for the page itself: a target that moves (http -> https,
+      # / -> /index.html, an apex -> www hop) would otherwise be parsed as an
+      # empty redirect body and silently report zero links.
+      response, final_uri = HttpClient.fetch(uri, options, headers, HttpClient::MAX_REDIRECTS)
+
+      unless response.status.success?
+        Deadfinder::Logger.error "Target page returned HTTP #{response.status_code} (links below, if any, come from that response): #{target}"
       end
+
+      page = Lexbor::Parser.new(response.body)
       links = extract_links(page)
 
       if !options.match.empty?
@@ -96,20 +70,41 @@ module Deadfinder
       link_info = links.compact_map { |type, urls|
         "#{type}:#{urls.size}" if urls.size > 0
       }.join(" / ")
-      Deadfinder::Logger.sub_info "Discovered #{total_links_count} URLs, currently checking them. [#{link_info}]" unless link_info.empty?
+      if link_info.empty?
+        # Say so explicitly: silence here used to be indistinguishable from a
+        # page that was fetched but never parsed.
+        Deadfinder::Logger.sub_info "Discovered 0 URLs on this page, nothing to check."
+      else
+        Deadfinder::Logger.sub_info "Discovered #{total_links_count} URLs, currently checking them. [#{link_info}]"
+      end
+
+      # Relative links resolve against `<base href>` when the document declares
+      # one, and otherwise against the URL the page was *finally* served from
+      # (which differs from `target` whenever the request was redirected).
+      base_url = document_base(page, final_uri.to_s)
 
       # Resolve all URLs and dedupe: distinct link nodes can resolve to the same
       # absolute URL, and each unique URL should be checked/recorded once per
-      # target. This also guarantees no two workers race on the same URL.
-      resolved_urls = all_links.compact_map { |node| Deadfinder.generate_url(node, target) }.uniq
+      # target.
+      resolved_urls = all_links.compact_map { |node| Deadfinder.generate_url(node, base_url) }.uniq
 
       # Channel-based concurrent workers. Guard against a non-positive
       # concurrency (e.g. `-c 0`): with zero workers nothing would drain `jobs`
       # and the main fiber would block forever on `results.receive`.
       worker_count = options.concurrency < 1 ? 1 : options.concurrency
 
-      jobs = Channel(String).new(1000)
-      results = Channel(String).new(1000)
+      # Group by the URL that is actually requested. A fragment is a client-side
+      # anchor and is never transmitted, so `/guide#install` and `/guide#usage`
+      # are one request while both still appear in the report. Grouping (rather
+      # than relying on the status cache) also keeps the guarantee that no two
+      # workers ever fetch the same URL concurrently.
+      grouped = {} of String => Array(String)
+      resolved_urls.each do |url|
+        (grouped[request_url(url)] ||= [] of String) << url
+      end
+
+      jobs = Channel(Tuple(String, Array(String))).new(1000)
+      results = Channel(Nil).new(1000)
 
       worker_count.times do |w|
         spawn do
@@ -117,10 +112,10 @@ module Deadfinder
         end
       end
 
-      jobs_size = resolved_urls.size
+      jobs_size = grouped.size
 
       spawn do
-        resolved_urls.each { |url| jobs.send(url) }
+        grouped.each { |request, originals| jobs.send({request, originals}) }
         jobs.close
       end
 
@@ -143,32 +138,37 @@ module Deadfinder
       Deadfinder::Logger.error "[#{ex}] #{target}"
     end
 
-    def worker(id : Int32, jobs : Channel(String), results : Channel(String),
+    def worker(id : Int32, jobs : Channel(Tuple(String, Array(String))), results : Channel(Nil),
                target : String, options : Options,
                output : Hash(String, Array(String)),
                coverage_data : Hash(String, TargetCoverage),
                status_cache : Hash(String, Int32),
                mutex : Mutex)
       loop do
-        url = jobs.receive? || break
+        job = jobs.receive? || break
+        request, linked_urls = job
 
         begin
-          status_code = resolve_status(url, status_cache, mutex, options)
-          record_total(target, options, coverage_data, mutex)
-          if status_code == ERROR_STATUS
-            record_error(target, url, options, output, coverage_data, mutex)
-          else
-            record_status(target, url, status_code, options, output, coverage_data, mutex)
+          status_code = resolve_status(request, status_cache, mutex, options)
+          # One request, but every link that pointed at it is recorded, so
+          # fragment variants are neither lost nor re-fetched.
+          linked_urls.each do |url|
+            record_total(target, options, coverage_data, mutex)
+            if status_code == ERROR_STATUS
+              record_error(target, url, options, output, coverage_data, mutex)
+            else
+              record_status(target, url, status_code, options, output, coverage_data, mutex)
+            end
           end
         rescue ex
           # A recording/logging failure (e.g. a broken STDOUT pipe under
           # `... | head`) must never kill the worker fiber or skip the result
           # send below — otherwise the main fiber blocks forever waiting for a
           # result that never arrives.
-          Deadfinder::Logger.verbose "[record failed: #{ex}] #{url}" if options.verbose
+          Deadfinder::Logger.verbose "[record failed: #{ex}] #{request}" if options.verbose
         ensure
           # Always report job completion so jobs_size accounting stays balanced.
-          results.send(url)
+          results.send(nil)
         end
       end
     end
@@ -196,22 +196,35 @@ module Deadfinder
       status
     end
 
+    # Checks a single link. Redirects are deliberately *not* followed here: the
+    # 30x status is itself the reported result (`--include30x`).
     private def check_url(url : String, options : Options) : Int32
       uri = URI.parse(url)
-      client = HttpClient.create(uri, options)
-      begin
-        headers = build_headers(options.worker_headers, options.user_agent)
+      headers = build_headers(options.worker_headers, options.user_agent)
+      response, _ = HttpClient.fetch(uri, options, headers)
+      response.status_code
+    end
 
-        path = if HttpClient.proxy_configured?(options) && uri.scheme == "http"
-                 HttpClient.absolute_uri(uri)
-               else
-                 request_path(uri)
-               end
-        response = client.get(path, headers: headers)
-        response.status_code
-      ensure
-        client.close
+    # A fragment is a client-side anchor and never reaches the server, so it is
+    # dropped from the URL that is actually requested.
+    private def request_url(url : String) : String
+      idx = url.index('#')
+      return url if idx.nil? || idx == 0
+      url[0, idx]
+    end
+
+    # Honors `<base href>` (the first one wins, per the HTML spec) so relative
+    # links on pages that declare a document base resolve the way a browser
+    # would instead of against the page URL.
+    private def document_base(page : Lexbor::Parser, page_url : String) : String
+      page.css("base").each do |element|
+        href = element.attribute_by("href")
+        next unless href
+        href = href.strip
+        next if href.empty?
+        return Deadfinder.generate_url(href, page_url) || page_url
       end
+      page_url
     end
 
     private def record_total(target : String, options : Options,

--- a/src/deadfinder/utils.cr
+++ b/src/deadfinder/utils.cr
@@ -10,19 +10,41 @@ module Deadfinder
     IGNORED_SCHEMES.any? { |scheme| url.starts_with?(scheme) }
   end
 
-  # True when `target` can actually be scanned: an absolute URL with an
-  # http/https scheme and a non-empty host. Everything else only produces a
-  # confusing failure downstream — a bare domain and a stray shell token both
-  # raise "URI is missing a host", `file:///etc/hosts` parses to an empty host
-  # and tries to connect to `:80`, and `ftp://host/x` would be fetched as plain
-  # HTTP — so callers report such lines and skip them instead.
-  def self.valid_target?(target : String) : Bool
-    uri = URI.parse(target)
+  # Returns nil when `url` can be used as a scan target, or a human-readable
+  # reason why it cannot. Everything rejected here only produces a confusing
+  # failure downstream — a bare domain and a stray shell token both raise
+  # "URI is missing a host", `file:///etc/hosts` parses to an empty host and
+  # tries to connect to `:80`, and `ftp://host/x` would be fetched as plain
+  # HTTP — so callers report the reason and skip the target instead.
+  def self.http_target_error(url : String) : String?
+    trimmed = url.strip
+    return "empty URL" if trimmed.empty?
+
+    uri = begin
+      URI.parse(trimmed)
+    rescue ex
+      return "invalid URL #{url.inspect}: #{ex.message}"
+    end
+
     scheme = uri.scheme
-    return false unless scheme == "http" || scheme == "https"
-    !uri.host.presence.nil?
-  rescue
-    false
+    if scheme.nil?
+      return "invalid URL #{url.inspect}: missing scheme, did you mean https://#{trimmed}?"
+    end
+    unless scheme == "http" || scheme == "https"
+      return "invalid URL #{url.inspect}: unsupported scheme #{scheme.inspect} (only http and https are supported)"
+    end
+    if uri.host.presence.nil?
+      return "invalid URL #{url.inspect}: missing host"
+    end
+
+    nil
+  end
+
+  # True when `target` can actually be scanned: an absolute URL with an
+  # http/https scheme and a non-empty host. Same rules as
+  # `http_target_error`, for callers that only need the yes/no.
+  def self.valid_target?(target : String) : Bool
+    http_target_error(target).nil?
   end
 
   def self.generate_url(text : String, base_url : String) : String?


### PR DESCRIPTION
## Summary

Audited the `url` and `sitemap` paths for bugs and unexpected behavior. Eight defects were confirmed with reproductions before fixing; each now has a regression spec.

The headline one: **scanning a page never followed redirects.** `deadfinder url http://example.com` on a site that moves to `https://` parsed the empty `30x` body — zero links discovered, no message, exit 0. Verified against a live site: `deadfinder url http://hahwul.com` discovered 0 URLs before, 65 after.

## What was broken

| | Before | After |
|---|---|---|
| Redirected target page | Empty 30x body parsed as the page — 0 links, silent | Follows up to 5 hops; relative links resolve against the final URL |
| Redirected sitemap | `Failed to fetch sitemap: HTTP 301` | Followed |
| `<base href>` | Ignored — relative links resolved against the page URL | Honored, browser-style |
| `/guide#install` + `/guide#usage` | Two requests for one resource | One request, both links still reported |
| Sitemap index with relative `<loc>` | `URI is missing a host` (page `<loc>`s were resolved, child sitemaps weren't) | Resolved against the parent sitemap |
| `--limit 1` on a sitemap index | Downloaded every child sitemap, discarded the surplus | Stops at the limit; the log says it stopped early |
| `deadfinder url example.com` | `⚠ [URI is missing a host]`, exit 0 | Actionable message with a scheme hint, exit 1 |
| Non-2xx target page | Scanned silently — error-page links looked like the real page's | Reported; a link-free page says so |

Plus two additions in the same paths: gzipped sitemaps (`sitemap.xml.gz` served as `application/gzip`, no `Content-Encoding`) are inflated, and `-H` now applies to the sitemap request, matching its documented "initial request" scope.

## Notes

- **Link status checks are unchanged.** They still pass 0 redirect hops, because there the `30x` *is* the result `--include30x` acts on. Covered by a spec asserting the `Location` target is never fetched, and recorded as an invariant in `AGENTS.md`.
- Credentials (`Authorization`, `Cookie`, `Proxy-Authorization`) are dropped when a redirect crosses origins, matching curl's default.
- Fixed an aliasing bug in that new code before it shipped: `HTTP::Headers` is a struct over a shared `Hash`, so `dup` + `delete` would have stripped the caller's headers too.
- Reports stay keyed by the target you asked for, even when the fetch was redirected.
- `build_headers` and the request-line construction moved into `HttpClient`; all three call sites (target page, sitemap, link check) now share one implementation instead of three copies.

## Rebased on #268

#268 landed `valid_target?` for `pipe`/`file` while this was open. Rather than keep two validators, `valid_target?` is now a thin wrapper over this PR's `http_target_error`, so all four subcommands share one rule set — `pipe`/`file` get the yes/no they need, `url`/`sitemap` get the reason to print.

## Verification

- `crystal spec` — 205 examples, 0 failures (36 new)
- `BIN=./deadfinder ruby spec/compat/run.rb` — passes, so the v1 golden-file output contract is intact
- `crystal tool format --check src spec` — clean
- Live smoke test against `http://hahwul.com` (redirect) and `https://www.hahwul.com/sitemap.xml --limit 2`